### PR TITLE
Add mocked balance history

### DIFF
--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -109,6 +109,43 @@ function get_history(success, error, tx_filter, offset, n) {
   });
 };
 
+function mock_async_get_balance_history(success, error) {
+  var history = [];
+
+  // Get the unix timestamp range for the last 30 days
+  var today = new Date();
+  var twentynine_days_ago = new Date();
+  twentynine_days_ago.setDate(twentynine_days_ago.getDate() - 29);
+  var thirty_days_range = (today - twentynine_days_ago);
+
+  // Generate between 0 and 30 history entries
+  var entries_to_generate = Math.floor(Math.random() * 30);
+
+  // Generate the requested number of history entries
+  for (var i = 0; i < entries_to_generate; i++) {
+    // Generate timestamp within last 30 days
+    var timestamp = Math.floor(Math.random() * thirty_days_range) + twentynine_days_ago;
+    // Generate random Bitcoin balance between 0BTC and 10BTC
+    var btcAmount = (Math.random() * 10);
+
+    history.push({'timestamp': timestamp, 'balance': btcAmount});
+  };
+
+  // Toss a loaded coin to see if the request succeeds or fails
+  var coinToss = Math.random();
+
+  // Let's say we have an 85% chance of success
+  if (coinToss > 0.15) {
+    // The request succeeded
+    success && success(history);
+  } else {
+    // The request failed
+    WalletStore.sendEvent("msg", {type: "error", message: 'Error Downloading Balance History'});
+
+    error();
+  }
+};
+
 function get_history_with_addresses(addresses, success, error, tx_filter, offset, n) {
   var clientTime=(new Date()).getTime();
 

--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -116,7 +116,7 @@ function mock_async_get_balance_history(success, error) {
   var today = new Date();
   var twentynine_days_ago = new Date();
   twentynine_days_ago.setDate(twentynine_days_ago.getDate() - 29);
-  var thirty_days_range = (today - twentynine_days_ago);
+  var thirty_days_range = (today.getTime() - twentynine_days_ago.getTime());
 
   // Generate between 0 and 30 history entries
   var entries_to_generate = Math.floor(Math.random() * 30);
@@ -124,7 +124,7 @@ function mock_async_get_balance_history(success, error) {
   // Generate the requested number of history entries
   for (var i = 0; i < entries_to_generate; i++) {
     // Generate timestamp within last 30 days
-    var timestamp = Math.floor(Math.random() * thirty_days_range) + twentynine_days_ago;
+    var timestamp = Math.floor(Math.random() * thirty_days_range) + twentynine_days_ago.getTime();
     // Generate random Bitcoin balance between 0BTC and 10BTC
     var btcAmount = (Math.random() * 10);
 

--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -539,6 +539,7 @@ function get_unspent(fromAddresses, success, error, confirmations) {
 module.exports = {
   getRootURL: getRootURL,
   get_history: get_history,
+  mock_async_get_balance_history: mock_async_get_balance_history,
   get_history_with_addresses: get_history_with_addresses,
   async_get_history_with_addresses: async_get_history_with_addresses,
   get_balances: get_balances,

--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -125,8 +125,8 @@ function mock_async_get_balance_history(success, error) {
   for (var i = 0; i < entries_to_generate; i++) {
     // Generate timestamp within last 30 days
     var timestamp = Math.floor(Math.random() * thirty_days_range) + twentynine_days_ago.getTime();
-    // Generate random Bitcoin balance between 0BTC and 10BTC
-    var btcAmount = (Math.random() * 10);
+    // Generate random Bitcoin balance between 0BTC and 10BTC, converted to Satoshi
+    var btcAmount = Math.floor(Math.random() * 10 * 100000000);
 
     history.push({'timestamp': timestamp, 'balance': btcAmount});
   };

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -965,6 +965,21 @@ MyWallet.getHistoryAndParseMultiAddressJSON = function(_success, _error) {
   }, _error, null, 0, 30);
 };
 
+MyWallet.getBalanceHistory = function(_success, _error) {
+  var success = function() {
+    _success && _success();
+  };
+
+  BlockchainAPI.mock_async_get_balance_history(function(data) {
+    // Do this here for now. If this gets more complicated,
+    // it should probably be moved to a new method
+    MyWallet.wallet.balanceHistory = data;
+    WalletStore.sendEvent('did_balance_history');
+
+    success && success();
+  }, _error);
+}
+
 // used once
 function checkWalletChecksum(payload_checksum, success, error) {
   var data = {method : 'wallet.aes.json', format : 'json', checksum : payload_checksum};

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -974,7 +974,7 @@ MyWallet.getBalanceHistory = function(_success, _error) {
     // Do this here for now. If this gets more complicated,
     // it should probably be moved to a new method
     MyWallet.wallet.balanceHistory = data;
-    WalletStore.sendEvent('did_balance_history');
+    WalletStore.sendEvent('did_load_balance_history');
 
     success && success();
   }, _error);

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -973,7 +973,7 @@ MyWallet.getBalanceHistory = function(_success, _error) {
   BlockchainAPI.mock_async_get_balance_history(function(data) {
     // Do this here for now. If this gets more complicated,
     // it should probably be moved to a new method
-    MyWallet.wallet.balanceHistory = data;
+    MyWallet.wallet.hdwallet.balanceHistory = data;
     WalletStore.sendEvent('did_load_balance_history');
 
     success && success();


### PR DESCRIPTION
See comments on https://github.com/blockchain/My-Wallet-V3-Frontend/pull/110

Would probably be better to return a sorted daily average balance for a specified date range (with last 30 days or maybe last 7 days being a "sane" default) instead of an unsorted, sparse array of unix timestamps and Satoshi amounts.

cc @Sjors 