### PR TITLE
Use text dataType for `getFiatAtTime`

### DIFF
--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -284,7 +284,7 @@ function getFiatAtTime(time, value, currencyCode, successCallback, errorCallback
     data: {value : value, currency: currencyCode, time: time, textual: false, nosavecurrency: true, api_code : WalletStore.getAPICode()},
     timeout: AJAX_TIMEOUT,
     success: function(data) {
-      successCallback(data);
+      successCallback(parseFloat(data));
     },
     error : function(e) {
       errorCallback(e);

--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -279,7 +279,7 @@ function sendViaSMS(number, tx, privateKey, successCallback, errorCallback) {
 function getFiatAtTime(time, value, currencyCode, successCallback, errorCallback) {
   $.ajax({
     type: "GET",
-    dataType: 'json',
+    dataType: 'text',
     url: getRootURL() +'frombtc',
     data: {value : value, currency: currencyCode, time: time, textual: false, nosavecurrency: true, api_code : WalletStore.getAPICode()},
     timeout: AJAX_TIMEOUT,

--- a/src/blockchain-api.js
+++ b/src/blockchain-api.js
@@ -284,7 +284,7 @@ function getFiatAtTime(time, value, currencyCode, successCallback, errorCallback
     data: {value : value, currency: currencyCode, time: time, textual: false, nosavecurrency: true, api_code : WalletStore.getAPICode()},
     timeout: AJAX_TIMEOUT,
     success: function(data) {
-      successCallback(parseFloat(data));
+      successCallback(parseFloat(data.replace(/,/g, '')));
     },
     error : function(e) {
       errorCallback(e);


### PR DESCRIPTION
Using JSON as the dataType causes problems because the server transmits amounts back **with commas** if they are above 999 (e.g. `2,105.83`). This messes up the JSON parsing and causes `$.ajax` to throw an error *even* if the request comes back correctly and with the expected data.

Noticed this when converting many BTC wallet amounts to fiat currency.