### PR TITLE
Update whitelist: create-hmac, create-hash, sha.js, added cipher-base 

### DIFF
--- a/dependency-whitelist.json
+++ b/dependency-whitelist.json
@@ -61,8 +61,8 @@
     "repo" : "walling/unorm"
   },
   "create-hash" : {
-    "version" : "1.1.1",
-    "commits" : ["45accafa2a45c4efa256b3d3e0645e3fa50bffd4"],
+    "version" : "1.1.2",
+    "commits" : ["426cefe8cae9feddda5af336d34e1d83bed13579"],
     "repo" : "crypto-browserify/createHash"
   },
   "ripemd160" : {
@@ -71,14 +71,19 @@
     "repo" : "crypto-browserify/ripemd160"
   },
   "sha.js" : {
-    "version" : "2.4.2",
-    "commits" : ["ee9184bb71cb672167b5f43f580ccb0cf9c22402"],
+    "version" : "2.4.4",
+    "commits" : ["8a30527c7e68d583785e8fd1aeebe004d8541bfc"],
     "repo" : "crypto-browserify/sha.js"
   },
   "create-hmac" : {
-    "version" : "1.1.3",
-    "commits" : ["0db078774769487d9ede6951a56c4cffe3de1c14"],
+    "version" : "1.1.4",
+    "commits" : ["3c7dd3047b5ab3e3be44d802241d224f0c9e2325"],
     "repo" : "crypto-browserify/createHmac"
+  },
+  "cipher-base" : {
+    "version" : "1.0.1",
+    "commits" : ["5f5eb4a23599806ef5f92aa25930ac0beeb35bd1"],
+    "repo" : "crypto-browserify/cipher-base"
   },
   "randombytes" : {
     "version" : "2.0.1",


### PR DESCRIPTION
https://github.com/crypto-browserify/createHmac/compare/v1.1.3...v1.1.4
https://github.com/crypto-browserify/createHash/compare/1.1.1...v1.1.2
https://github.com/crypto-browserify/cipher-base/blob/master/index.js
https://github.com/crypto-browserify/sha.js/compare/v2.4.2...v2.4.4