### PR TITLE
Don't reuse labeled receive index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-wallet-client",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Blockchain.info JavaScript Wallet",
   "homepage": "https://github.com/blockchain/My-Wallet-HD",
   "bugs": {

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -342,8 +342,11 @@ Wallet.prototype._updateWalletInfo = function(obj) {
       if (account){
         account.balance      = e.final_balance;
         account.n_tx         = e.n_tx;
-        account.receiveIndex = e.account_index;
+        account.lastUsedReceiveIndex = e.account_index;
+        account.receiveIndex = Math.max(account.lastUsedReceiveIndex, account.maxLabeledReceiveIndex);
+
         account.changeIndex  = e.change_index;
+
         if (account.getLabelForReceivingAddress(account.receiveIndex)) {
           account.incrementReceiveIndex();
         };

--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -3,6 +3,7 @@
 module.exports = HDAccount;
 ////////////////////////////////////////////////////////////////////////////////
 var Bitcoin = require('bitcoinjs-lib');
+var Q       = require('q');
 var assert  = require('assert');
 var Helpers = require('./helpers');
 var WalletCrypto = require('./wallet-crypto');
@@ -30,6 +31,8 @@ function HDAccount(object){
   // computed properties
   this._keyRing       = new KeyRing(obj.xpub, obj.cache);
   this._receiveIndex  = 0;
+  // The highest receive index with transactions, as returned by the server:
+  this._lastUsedReceiveIndex = 0;
   this._changeIndex   = 0;
   this._n_tx          = 0;
   this._balance       = null;
@@ -102,6 +105,29 @@ Object.defineProperties(HDAccount.prototype, {
         this._receiveIndex = value;
       else
         throw 'Error: account.receiveIndex must be a number';
+    }
+  },
+  "lastUsedReceiveIndex": {
+    configurable: false,
+    get: function() { return this._lastUsedReceiveIndex;},
+    set: function(value) {
+      if(Helpers.isNumber(value))
+        this._lastUsedReceiveIndex = value;
+      else
+        throw 'Error: account.lastUsedReceiveIndex must be a number';
+    }
+  },
+  "maxLabeledReceiveIndex" : {
+    configurable: false,
+    get: function() {
+      var keys = Object.keys(this._address_labels).map(function(k) {
+        return parseInt(k);
+      });
+      if (keys.length == 0) {
+        return -1;
+      } else {
+        return Math.max.apply(null, keys);
+      }
     }
   },
   "changeIndex": {
@@ -250,11 +276,24 @@ HDAccount.prototype.incrementReceiveIndexIfLast = function(index) {
 // address labels
 HDAccount.prototype.setLabelForReceivingAddress = function(index, label) {
   assert(Helpers.isNumber(index), "Error: address index must be a number");
-  assert(Helpers.isValidLabel(label), "Error: address label must be alphanumeric");
-  this._address_labels[index] = label;
-  this.incrementReceiveIndexIfLast(index);
-  MyWallet.syncWallet();
-  return this;
+
+  var defer = Q.defer();
+
+  if(!Helpers.isValidLabel(label)) {
+    defer.reject("NOT_ALPHANUMERIC");
+    // Error: address label must be alphanumeric
+  } else if (index - this.lastUsedReceiveIndex >= 20) {
+    // Exceeds BIP 44 unused address gap limit
+    defer.reject("GAP");
+  } else {
+    this._address_labels[index] = label;
+    this.incrementReceiveIndexIfLast(index);
+    MyWallet.syncWallet();
+
+    defer.resolve();
+  }
+
+  return defer.promise;
 };
 
 HDAccount.prototype.getLabelForReceivingAddress = function(index) {

--- a/tests/hdaccount_spec.js.coffee
+++ b/tests/hdaccount_spec.js.coffee
@@ -132,10 +132,15 @@ describe "HDAccount", ->
     describe ".get/setLabelForReceivingAddress", ->
 
       it 'should set the label sync and get the label', ->
-        account.setLabelForReceivingAddress(100, "my label")
-        expect(account._address_labels[100]).toEqual("my label")
+        fail = (reason) ->
+          console.log(reason)
+
+        success = () ->
+
+        account.setLabelForReceivingAddress(10, "my label").then(success).catch(fail)
+        expect(account._address_labels[10]).toEqual("my label")
         expect(MyWallet.syncWallet).toHaveBeenCalled()
-        expect(account.getLabelForReceivingAddress(100)).toEqual("my label")
+        expect(account.getLabelForReceivingAddress(10)).toEqual("my label")
 
     describe "Setter", ->
 
@@ -269,4 +274,3 @@ describe "HDAccount", ->
         expect(account.extendedPrivateKey).toEqual(temp)
         expect(account._temporal_xpriv).not.toBeDefined()
         expect(MyWallet.syncWallet).not.toHaveBeenCalled()
-


### PR DESCRIPTION
Breaking change for setLabelForReceivingAddress(), so I increased the
minor version in package.json.

Needed by blockchain/My-Wallet-V3-Frontend#187