### PR TITLE
show first recovered account in recovery progress for busy view in iOS

### DIFF
--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -622,8 +622,7 @@ Wallet.prototype.restoreHDWallet = function(mnemonic, bip39Password, pw, progres
   var encoder = WalletCrypto.cipherFunction(pw, this._sharedKey, this._pbkdf2_iterations, "enc");
   var newHDwallet = HDWallet.restore(seedHex, pass39, encoder);
   this._hd_wallets[0] = newHDwallet;
-  var account = this.newAccount("Account 1", pw, 0, undefined, true);
-  var accountIndex  = 1;
+  var accountIndex  = 0;
   var AccountsGap = 10;
 
   var untilNEmptyAccounts = function(n){
@@ -636,7 +635,7 @@ Wallet.prototype.restoreHDWallet = function(mnemonic, bip39Password, pw, progres
       return true;
     } else{
       accountIndex++;
-      account = self.newAccount("Account " + accountIndex.toString(), pw, 0, undefined, true);
+      var account = self.newAccount("Account " + accountIndex.toString(), pw, 0, undefined, true);
       return isAccountNonUsed(account, progress).then(go);
     };
   };


### PR DESCRIPTION
Previously the progress function would start with the second recovered account obj.