### PR TITLE
Make installing with npm 3+ work

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/blockchain/My-Wallet-HD.git"
   },
   "scripts": {
-    "postinstall": "cd node_modules/sjcl && ./configure --with-sha1 && make",
+    "postinstall": "cd node_modules/sjcl || cd ../sjcl && ./configure --with-sha1 && make",
     "test": "./node_modules/karma/bin/karma start karma.conf.js"
   },
   "dependencies": {


### PR DESCRIPTION
In npm version 3 and up, dependencies are installed differently (side-by-side, rather than in a tree structure). This broke the `postinstall` script, which uses a relative path to configure the `sjcl` dependency.