### PR TITLE
fix(encoding): set stream encoding to utf8 on request end

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -88,7 +88,7 @@ API.prototype.request = function(action, method, data, withCred) {
   var body = this.encodeFormData(data);
   if (action === "GET") {url = url + '?'  + body;}
   var r = hyperquest(url, requestOptions);
-  if (action === "POST") { r.end(body); }
+  if (action === "POST") { r.end(body, 'utf8'); }
   timeout(r, this.AJAX_TIMEOUT);
 
   r.on('response', function(res) {


### PR DESCRIPTION
Explicitly sets the encoding type to prevent a fatal error when `this._writableState` inside of a call to `Writable.prototype.end` is for some reason undefined.