### PR TITLE
refactor(api): use fetch rather than hyperquest

### DIFF
--- a/dependency-whitelist.json
+++ b/dependency-whitelist.json
@@ -105,10 +105,15 @@
     "commits" : ["d373079d3620152e3d60e82f27265a09ee0e81bd"],
     "repo" : "kriskowal/q"
   },
-  "hyperquest" : {
-    "version" : "1.2.0",
-    "commits" : ["6e659e313f9fd2d5627f6c647ba0d17098d4a79d"],
-    "repo" : "substack/hyperquest"
+  "es6-promise" : {
+    "version" : "3.0.2",
+    "commits" : ["7d90241d79d8a50e340abb3d964c47fe79a214ba"],
+    "repo" : "jakearchibald/es6-promise"
+  },
+  "isomorphic-fetch" : {
+    "version" : "2.2.0",
+    "commits" : ["43437dc5b381e391b73522d71cea23fc72675154"],
+    "repo" : "matthew-andrews/isomorphic-fetch"
   },
   "pbkdf2" : {
     "version" : "3.0.4",

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 'use strict';
 
+require('es6-promise').polyfill();
+require('isomorphic-fetch');
+
 var Buffer = require('buffer').Buffer
 
 // This fixes a bug with Safari < 8 and the Browserify Buffer shim used in Crypto-browserify/randombytes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-wallet-client",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "description": "Blockchain.info JavaScript Wallet",
   "homepage": "https://github.com/blockchain/my-wallet-v3",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -33,13 +33,14 @@
     "bitcoinjs-lib": "1.5.*",
     "bs58": "2.0.*",
     "crypto-js": "3.1.4",
+    "es6-promise": "^3.0.2",
+    "isomorphic-fetch": "^2.2.0",
     "q": "^1.4.1",
     "randombytes": "^2.0.1",
     "rsvp": "^3.1.0",
     "sjcl": "1.0.*",
     "unorm": "^1.4.1",
     "ws": "^0.8.0",
-    "hyperquest": "^1.2.0",
     "xregexp": "2.0.*"
   },
   "devDependencies": {

--- a/src/api.js
+++ b/src/api.js
@@ -45,11 +45,6 @@ API.prototype.request = function(action, method, data, withCred) {
   if (action === 'GET') url += '?' + body;
   if (action === 'POST') options.body = body;
 
-  var loadEnded = function (response) {
-    WalletStore.sendEvent('msg', {type: 'ajax-end', message: 'ajax call ended'});
-    return response;
-  };
-
   var checkStatus = function (response) {
     if (response.status >= 200 && response.status < 300) {
       return data.format === 'json' ? response.json() : response.text();
@@ -72,10 +67,7 @@ API.prototype.request = function(action, method, data, withCred) {
     return deferred.promise;
   };
 
-  WalletStore.sendEvent('msg', {type: 'ajax-start', message: 'ajax call started'});
-
   return fetch(url, options)
-    .then(loadEnded)
     .then(checkStatus)
     .then(handleResponse)
     .catch(handleError);

--- a/src/api.js
+++ b/src/api.js
@@ -65,12 +65,20 @@ API.prototype.request = function(action, method, data, withCred) {
     return response;
   }.bind(this);
 
+  var handleError = function (err) {
+    var deferred = Q.defer();
+    if (err.response) err.response.text().then(deferred.reject);
+    else deferred.reject('Network Error');
+    return deferred.promise;
+  };
+
   WalletStore.sendEvent('msg', {type: 'ajax-start', message: 'ajax call started'});
 
   return fetch(url, options)
     .then(loadEnded)
     .then(checkStatus)
-    .then(handleResponse);
+    .then(handleResponse)
+    .catch(handleError);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/api.js
+++ b/src/api.js
@@ -8,7 +8,6 @@ var Helpers     = require('./helpers');
 var WalletStore = require('./wallet-store');
 var CryptoJS    = require('crypto-js');
 var MyWallet    = require('./wallet');
-var hyperquest  = require('hyperquest');
 var Buffer      = require('buffer').Buffer;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -33,81 +32,45 @@ API.prototype.encodeFormData = function (data) {
 
 ////////////////////////////////////////////////////////////////////////////////
 API.prototype.request = function(action, method, data, withCred) {
+  var url   = this.ROOT_URL + method
+    , body  = this.encodeFormData(data)
+    , time  = (new Date()).getTime();
 
-  var defer = Q.defer();
-  var url = this.ROOT_URL + method;
-  var clientTime = (new Date()).getTime();
-  // this is used on iOS to enable and disable web socket while doing ajax calls
-  WalletStore.sendEvent("msg", {type: "ajax-start", message: 'ajax call started'});
-  //////////////////////////////////////////////////////////////////////////////
-  // Helpers:
-  var readData = function(res, callback){
-    var buffer = new Buffer('');
-    res.on('data', function(chunk) {
-      buffer = Buffer.concat([buffer, chunk]);
-    });
-
-    res.on('end', function () {
-      var resString = buffer.toString('utf8');
-      callback(resString);
-    })
-  }
-
-  var timeout = function (req, ms) {
-    var t = setTimeout(function() {
-      req.emit('error', new Error('timeout: ' + ms + ' ms'));
-    }, ms);
-    req.on('response', function() { clearTimeout(t); });
-    return req;
-  }
-
-  function loadEnded() {
-    // this is used on iOS to enable and disable web socket while doing ajax calls
-    WalletStore.sendEvent("msg", {type: "ajax-end", message: 'ajax call ended'});
-  }
-
-  var handleResponse = function (res) {
-    loadEnded();
-    this.handleNTPResponse(res, clientTime);
-    if (data.format === 'json') { res = JSON.parse(res); }
-    defer.resolve(res);
-  }.bind(this);
-
-  var handleError = function (err) {
-    loadEnded();
-    defer.reject(err);
-  }.bind(this);
-  //////////////////////////////////////////////////////////////////////////////
-
-  var wc = withCred ? true : false;
-  var requestOptions = {
-    method    : action,
-    withCredentials: wc
+  var options = {
+    method      : action,
+    headers     : { 'Content-Type': 'application/x-www-form-urlencoded' },
+    credentials : withCred ? 'same-origin' : false
   };
-  requestOptions.headers = { 'Content-Type': 'application/x-www-form-urlencoded'}
-  var body = this.encodeFormData(data);
-  if (action === "GET") {url = url + '?'  + body;}
-  var r = hyperquest(url, requestOptions);
-  if (action === "POST") { r.end(body, 'utf8'); }
-  timeout(r, this.AJAX_TIMEOUT);
 
-  r.on('response', function(res) {
-    switch (true) {
-      case (res.statusCode === 200):
-        readData(r, handleResponse);
-        break;
-      case (res.statusCode === 500):
-        readData(r, handleError);
-        break;
-      default:
-        handleError('Bad statusCode in response: '+ res.statusCode)
+  if (action === 'GET') url += '?' + body;
+  if (action === 'POST') options.body = body;
+
+  var loadEnded = function (response) {
+    WalletStore.sendEvent('msg', {type: 'ajax-end', message: 'ajax call ended'});
+    return response;
+  };
+
+  var checkStatus = function (response) {
+    if (response.status >= 200 && response.status < 300) {
+      return data.format === 'json' ? response.json() : response.text();
+    } else {
+      var error = new Error(response.statusText);
+      error.response = response;
+      throw error;
     }
-  });
+  };
 
-  r.on('error', function(err) { defer.reject("unknown error"); });
+  var handleResponse = function (response) {
+    this.handleNTPResponse(response, time);
+    return response;
+  }.bind(this);
 
-  return defer.promise;
+  WalletStore.sendEvent('msg', {type: 'ajax-start', message: 'ajax call started'});
 
+  return fetch(url, options)
+    .then(loadEnded)
+    .then(checkStatus)
+    .then(handleResponse);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I swapped out our hyperquest dependency for fetch for two reasons:

1. hyperquest is causing problems by crashing frequently for some users (see service-my-wallet-v3 issues)
2. fetch makes sense as it is a new web standard

I also think it has a better api, since it uses promises rather than streams. For our use case, using streams is most likely overkill.

Tested in Node and in Chrome. Should test in iOS and other browsers before merging.