### PR TITLE
chore(logging): remove console logs that show messages when browser globals are undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ try {
     }
   }
 } catch (e) {
-  console.log(e);
 }
 
 module.exports = {

--- a/src/shared.js
+++ b/src/shared.js
@@ -79,7 +79,6 @@ try {
     }
   }
 } catch (e) {
-  console.log(e);
 }
 //The current 'shift' value - BTC = 1, mBTC = 3, uBTC = 6
 function sShift(symbol) {


### PR DESCRIPTION
Happens in node. Seeng `[ReferenceError: window is not defined]` all the time gets annoying, and might unnerve users.