### PR TITLE
fix(importLegacy): catch import errors within closure

### DIFF
--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -494,7 +494,10 @@ Wallet.prototype.importLegacyAddress = function (addr, label, secPass, bipPass) 
       }
       ImportExport.parseBIP38toECKey(
         addr, bipPass,
-        function (key) { resolve(importAddress(key)); },
+        function (key) {
+          try       { resolve(importAddress(key));  }
+          catch (e) { reject(e);                    }
+        },
         function () { reject('wrongBipPass'); },
         function () { reject('importError'); }
       );


### PR DESCRIPTION
The function passes to the Promise constructor won't catch errors that are deep within closures, for some reason, so we need to try/catch them.