### PR TITLE
add success callback to resend two factor for SMS

### DIFF
--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -34,10 +34,7 @@ function resendTwoFactorSms(user_guid, success) {
     api_code : API.API_CODE
   };
 
-  var successCallback = function(obj) {
-    success();
-    if (obj.success) return obj.message;
-  }
+  var successCallback = function(obj) { success(); return obj;}
 
   var handleError = function (e) {
     var errMsg = e.responseJSON && e.responseJSON.initial_error ?

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -36,7 +36,7 @@ function resendTwoFactorSms(user_guid, success) {
 
   var successCallback = function(obj) {
     success();
-    if (obj.success) return obj.message;}
+    if (obj.success) return obj.message;
   }
 
   var handleError = function (e) {

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -34,7 +34,10 @@ function resendTwoFactorSms(user_guid, success) {
     api_code : API.API_CODE
   };
 
-  var successCallback = function(obj) { success(); return obj.message;}
+  var successCallback = function(obj) {
+    success();
+    if (obj.success) return obj.message;}
+  }
 
   var handleError = function (e) {
     var errMsg = e.responseJSON && e.responseJSON.initial_error ?

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -34,7 +34,9 @@ function resendTwoFactorSms(user_guid, success) {
     api_code : API.API_CODE
   };
 
-  var successCallback = function(obj) { success(); return obj;}
+  var successCallback = function(obj) {if (obj.success) {success();}
+    return obj.message;
+  }
 
   var handleError = function (e) {
     var errMsg = e.responseJSON && e.responseJSON.initial_error ?

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -25,7 +25,7 @@ function generateUUIDs(count) {
  * @param {string} user_guid User GUID.
  */
 // used in the frontend
-function resendTwoFactorSms(user_guid) {
+function resendTwoFactorSms(user_guid, success) {
 
   var data = {
     format : 'json',
@@ -34,6 +34,8 @@ function resendTwoFactorSms(user_guid) {
     api_code : API.API_CODE
   };
 
+  var successCallback = function(obj) { success(); }
+
   var handleError = function (e) {
     var errMsg = e.responseJSON && e.responseJSON.initial_error ?
       e.responseJSON.initial_error : e || 'Could not resend two factor sms';
@@ -41,6 +43,7 @@ function resendTwoFactorSms(user_guid) {
   };
 
   return API.request('GET', 'wallet/' + user_guid, data, true, false)
+    .then(successCallback)
     .catch(handleError);
 };
 

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -34,9 +34,7 @@ function resendTwoFactorSms(user_guid, success) {
     api_code : API.API_CODE
   };
 
-  var successCallback = function(obj) {if (obj.success) {success();}
-    return obj.message;
-  }
+  var successCallback = function(obj) { success(); return obj.message;}
 
   var handleError = function (e) {
     var errMsg = e.responseJSON && e.responseJSON.initial_error ?

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -25,7 +25,7 @@ function generateUUIDs(count) {
  * @param {string} user_guid User GUID.
  */
 // used in the frontend
-function resendTwoFactorSms(user_guid, success, error) {
+function resendTwoFactorSms(user_guid, success) {
 
   var data = {
     format : 'json',

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -25,7 +25,7 @@ function generateUUIDs(count) {
  * @param {string} user_guid User GUID.
  */
 // used in the frontend
-function resendTwoFactorSms(user_guid, success) {
+function resendTwoFactorSms(user_guid, success, error) {
 
   var data = {
     format : 'json',
@@ -34,7 +34,7 @@ function resendTwoFactorSms(user_guid, success) {
     api_code : API.API_CODE
   };
 
-  var successCallback = function(obj) { success(); }
+  var successCallback = function(obj) { success(); return obj;}
 
   var handleError = function (e) {
     var errMsg = e.responseJSON && e.responseJSON.initial_error ?


### PR DESCRIPTION
iOS relies on success callback to open alert back up after resending.

'Account Locked' error is showing in alerts with current error handling.