### PR TITLE
fix(websocket): catch error if websocket fails to connect

### DIFF
--- a/src/blockchain-socket.js
+++ b/src/blockchain-socket.js
@@ -41,10 +41,14 @@ BlockchainSocket.prototype.connect = function (onOpen, onMessage, onClose) {
 };
 
 BlockchainSocket.prototype.connectOnce = function (onOpen, onMessage, onClose) {
-  this.socket = new WebSocket(this.wsUrl, [], { headers: this.headers });
-  this.socket.on('open', onOpen);
-  this.socket.on('message', onMessage);
-  this.socket.on('close', onClose);
+  try {
+    this.socket = new WebSocket(this.wsUrl, [], { headers: this.headers });
+    this.socket.on('open', onOpen);
+    this.socket.on('message', onMessage);
+    this.socket.on('close', onClose);
+  } catch (e) {
+    console.log('Failed to connect to websocket');
+  }
 };
 
 BlockchainSocket.prototype.send = function (message) {


### PR DESCRIPTION
This was causing frequent crashes for users of service-my-wallet-v3. The server would occasionally respond with a status of 522 when the websocket was trying to connect, and since the error doesn't get caught, the whole program crashes.