### PR TITLE
define every() for Buffers in iOS

### DIFF
--- a/src/rng.js
+++ b/src/rng.js
@@ -36,20 +36,15 @@ RNG.prototype.xor = function (a, b) {
 
 // run :: Int -> Fun -> Buffer
 RNG.prototype.run = function (sizeBytes, callback) {
-  if(!Buffer.prototype.every || typeof(Buffer.prototype.every) !== "function") {
-    // iOs workaround:
-    Buffer.prototype.every = Array.prototype.every;
-  }
-
   try {
     var b = sizeBytes ? sizeBytes : this.BYTES;
     var serverH = this.getServerEntropy(b);
-    assert(!serverH.every(function(byte){return byte === serverH[0]}), 'The server entropy should not be the same byte repeated.');
+    assert(!Array.prototype.every.call(serverH, function(byte){return byte === serverH[0]}), 'The server entropy should not be the same byte repeated.');
     var localH = randomBytes(b, callback);
-    assert(!localH.every(function(byte){return byte === localH[0]}), 'The browser entropy should not be the same byte repeated.');
+    assert(!Array.prototype.every.call(localH, function(byte){return byte === localH[0]}), 'The browser entropy should not be the same byte repeated.');
     assert(serverH.byteLength === localH.byteLength, 'Error: both entropies should be same of the length.');
     var combinedH = this.xor(localH, serverH);
-    assert(!combinedH.every(function(byte){return byte === combinedH[0]}), 'The combined entropy should not be the same byte repeated.');
+    assert(!Array.prototype.every.call(combinedH, function(byte){return byte === combinedH[0]}), 'The combined entropy should not be the same byte repeated.');
     assert(combinedH.byteLength === b, 'Error: combined entropy should be of requested length.');
     var zero = new Buffer(serverH.byteLength);
     assert(Buffer.compare(combinedH, zero) !== 0, 'Error: zero array entropy not allowed.');

--- a/src/rng.js
+++ b/src/rng.js
@@ -36,6 +36,11 @@ RNG.prototype.xor = function (a, b) {
 
 // run :: Int -> Fun -> Buffer
 RNG.prototype.run = function (sizeBytes, callback) {
+  if(!Buffer.prototype.every || typeof(Buffer.prototype.every) !== "function") {
+    // iOs workaround:
+    Buffer.prototype.every = Array.prototype.every;
+  }
+
   try {
     var b = sizeBytes ? sizeBytes : this.BYTES;
     var serverH = this.getServerEntropy(b);

--- a/src/rng.js
+++ b/src/rng.js
@@ -39,6 +39,7 @@ RNG.prototype.run = function (sizeBytes, callback) {
   try {
     var b = sizeBytes ? sizeBytes : this.BYTES;
     var serverH = this.getServerEntropy(b);
+    // in iOS, every() cannot be called on a Buffer object, so use Array.prototype.every.call(sizeBytes, f)
     assert(!Array.prototype.every.call(serverH, function(byte){return byte === serverH[0]}), 'The server entropy should not be the same byte repeated.');
     var localH = randomBytes(b, callback);
     assert(!Array.prototype.every.call(localH, function(byte){return byte === localH[0]}), 'The browser entropy should not be the same byte repeated.');


### PR DESCRIPTION
For some reason every() cannot be called on a Buffer object in iOS.

The code inside the If statement is not executed on Frontend (Chrome 48).