### PR TITLE
Added grunt-semistandard to Gruntfile

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -170,6 +170,10 @@ module.exports = (grunt) ->
           grep_commits: '^fix|^feat|^docs|^refactor|^chore|^test|BREAKING'
           repo_url: 'https://github.com/blockchain/My-Wallet-V3'
 
+    semistandard:
+      app:
+        src:
+          ['{,src/}*.js']
 
   grunt.loadNpmTasks 'grunt-browserify'
   grunt.loadNpmTasks 'grunt-contrib-clean'
@@ -181,8 +185,9 @@ module.exports = (grunt) ->
   grunt.loadNpmTasks 'grunt-preprocess'
   grunt.loadNpmTasks 'grunt-shell'
   grunt.loadNpmTasks 'grunt-text-replace'
-  grunt.loadNpmTasks('git-changelog')
-  grunt.loadNpmTasks('grunt-karma-coveralls')
+  grunt.loadNpmTasks 'git-changelog'
+  grunt.loadNpmTasks 'grunt-karma-coveralls'
+  grunt.loadNpmTasks 'grunt-semistandard'
 
   grunt.registerTask "default", [
     "build"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "grunt-env": "^0.4.4",
     "grunt-karma-coveralls": "^2.5.4",
     "grunt-preprocess": "^4.1.0",
+    "grunt-semistandard": "^1.0.5",
     "grunt-shell": "^1.1.2",
     "grunt-text-replace": "^0.4.0",
     "jasmine-core": "^2.2.0",


### PR DESCRIPTION
Following discussion on PR #111, I added a new task to grunt to see lint errors.
Can be run using ```grunt semistandard```.