### PR TITLE
Refresh transactions n seconds after spend (partial)

### DIFF
--- a/src/payment.js
+++ b/src/payment.js
@@ -332,9 +332,23 @@ Payment.publish = function() {
   return function (payment) {
 
     var success = function (tx_hash) {
-      console.log("published");
       payment.txid = tx_hash;
-      return payment;
+
+      // Normally the transaction is returned via a web socket.
+      // Perform a manual refresh after 1 second just in case, as
+      // well as for TOR.
+      return new Promise(function(resolve, reject) {
+        setTimeout(
+          function() {
+            MyWallet.wallet.txList.fetchTxs(1, 0, true)
+              .then(function() {
+                resolve(payment);
+              })
+              .catch(function(e) { reject({ error: e, payment: payment }); });
+          },
+          2000
+        );
+      });
     };
 
     var handleError = function (e) {

--- a/src/transaction-list.js
+++ b/src/transaction-list.js
@@ -41,15 +41,19 @@ Object.defineProperties(TransactionList.prototype, {
   }
 });
 
-TransactionList.prototype.fetchTxs = function (amount) {
+TransactionList.prototype.fetchTxs = function (amount, offset, shift) {
   var refresh = this._getContext().join() !== this._context.join()
     , context = this._context = refresh ? this._getContext() : this._context
-    , txIndex = refresh ? 0 : this._txsFetched
+    , txIndex = Helpers.isNumber(offset) ? offset : (refresh ? 0 : this._txsFetched)
     , amount  = amount || this.loadNumber
     , txListP = API.getHistory(context, null, txIndex, amount);
   var processTxs = (function (data) {
     if (refresh) { this._transactions = []; this._txsFetched = 0; }
-    this.pushTxs(data.txs);
+    if(shift) {
+      this.shiftTxs(data.txs);
+    } else {
+      this.pushTxs(data.txs);
+    }
     this._txsFetched += data.txs.length;
     return data.txs.length;
   }).bind(this);


### PR DESCRIPTION
This code works if you disable web sockets (e.g. by setting `WEBSOCKET_URL=` in `.env`).

Two issues:
1 - if you set the interval too short (e.g. 1 second), the new transaction isn't found and the screen doesn't update; too long and the UI delay becomes annoying
2 - not tested with web sockets enabled

Path forward:
* separate the transaction update call from the promise; it should notify the frontend some other way when it's, e.g. via on_tx
* wait e.g. 5 seconds or repeat every second for a max of e.g. 30 seconds
* store the transaction id returned by push_tx so we know when it's detected

cc @pernas 