### PR TITLE
refactor(helpers): some functions moved from MyWallet to Helpers.

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -181,7 +181,7 @@ Address.fromString = function(keyOrAddr, label, bipPass){
       return resolve(Address.import(keyOrAddr, label));
     } else {
       // Import private key
-      var format    = MyWallet.detectPrivateKeyFormat(keyOrAddr)
+      var format    = Helpers.detectPrivateKeyFormat(keyOrAddr)
         , okFormats = ['base58', 'base64', 'hex', 'mini', 'sipa', 'compsipa'];
 
       if (format === 'bip38') {

--- a/src/payment.js
+++ b/src/payment.js
@@ -206,7 +206,7 @@ Payment.amount = function(amounts) {
 Payment.from = function(origin) {
   var addresses  = null;
   var change     = null;
-  var pkFormat   = MyWallet.detectPrivateKeyFormat(origin);
+  var pkFormat   = Helpers.detectPrivateKeyFormat(origin);
   var wifs       = []; // only used fromPrivateKey
   var fromAccId  = null;
 
@@ -385,7 +385,7 @@ function getKeyForAddress(password, addr) {
                                                 , password
                                                 , MyWallet.wallet.sharedKey
                                                 , MyWallet.wallet.pbkdf2_iterations);
-  var format = MyWallet.detectPrivateKeyFormat(privateKeyBase58);
+  var format = Helpers.detectPrivateKeyFormat(privateKeyBase58);
   var key    = Helpers.privateKeyStringToKey(privateKeyBase58, format);
   if (MyWallet.getCompressedAddressString(key) === addr) {
     key = new Bitcoin.ECKey(key.d, true);

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -16,7 +16,6 @@ var WalletSignup = require('./wallet-signup');
 var API = require('./api');
 var Wallet = require('./blockchain-wallet');
 var Helpers = require('./helpers');
-var shared = require('./shared');
 var BlockchainSocket = require('./blockchain-socket');
 
 var isInitialized = false;
@@ -182,7 +181,7 @@ function socketConnect() {
  */
  // used only on the frontend
 MyWallet.getBalanceForRedeemCode = function(privatekey, successCallback, errorCallback)  {
-  var format = MyWallet.detectPrivateKeyFormat(privatekey);
+  var format = Helpers.detectPrivateKeyFormat(privatekey);
   if(format == null) {
     errorCallback("Unkown private key format");
     return;
@@ -203,15 +202,6 @@ MyWallet.getBalanceForRedeemCode = function(privatekey, successCallback, errorCa
     .catch(errorCallback);
 };
 
-/**
- * @param {string} mnemonic mnemonic
- * @return {boolean} is valid mnemonic
- */
- // should be moved to helpers
-MyWallet.isValidateBIP39Mnemonic = function(mnemonic) {
-  return BIP39.validateMnemonic(mnemonic);
-};
-
 // used only locally (wallet.js)
 MyWallet.listenToHDWalletAccount = function(accountExtendedPublicKey) {
   try {
@@ -225,34 +215,6 @@ MyWallet.listenToHDWalletAccounts = function() {
     var listen = function(a) { MyWallet.listenToHDWalletAccount(a.extendedPublicKey); }
     MyWallet.wallet.hdwallet.activeAccounts.forEach(listen);
   };
-};
-
-
-/**
- * @param {string} candidate candidate address
- * @return {boolean} is valid address
- */
- // TODO: This should be a helper
- // used on wallet-store, frontend and iOS,
-MyWallet.isValidAddress = function(candidate) {
-  return Helpers.isBitcoinAddress(candidate);
-};
-
-/**
- * @param {string} candidate candidate PrivateKey
- * @return {boolean} is valid PrivateKey
- */
- // used on the frontend
- // TODO: this should be a helper
-MyWallet.isValidPrivateKey = function(candidate) {
-  try {
-    var format = MyWallet.detectPrivateKeyFormat(candidate);
-    if(format == "bip38") { return true }
-    var key = Helpers.privateKeyStringToKey(candidate, format);
-    return key.pub.getAddress().toString();
-  } catch (e) {
-    return false;
-  }
 };
 
 // used two times
@@ -783,99 +745,4 @@ MyWallet.logout = function(force) {
   var data = {format : 'plain', api_code : API.API_CODE};
   WalletStore.sendEvent('logging_out');
   API.request("GET", 'wallet/logout', data, true, false).then(reload).catch(reload);
-};
-
-// used locally and iOS
-// should be a helper
-MyWallet.detectPrivateKeyFormat = function(key) {
-  // 51 characters base58, always starts with a '5'
-  if (/^5[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}$/.test(key))
-    return 'sipa';
-
-  //52 character compressed starts with L or K
-  if (/^[LK][123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{51}$/.test(key))
-    return 'compsipa';
-
-  // 40-44 characters base58
-  if (Helpers.isBase58Key(key))
-    return 'base58';
-
-  if (/^[A-Fa-f0-9]{64}$/.test(key))
-    return 'hex';
-
-  if (/^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789=+\/]{44}$/.test(key))
-    return 'base64';
-
-  if (/^6P[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{56}$/.test(key))
-    return 'bip38';
-
-  if (/^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{21}$/.test(key) ||
-      /^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{25}$/.test(key) ||
-      /^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{29}$/.test(key) ||
-      /^S[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{30}$/.test(key)) {
-
-    var testBytes = Bitcoin.crypto.sha256(key + "?");
-
-    if (testBytes[0] === 0x00 || testBytes[0] === 0x01)
-      return 'mini';
-  }
-
-  console.error('Unknown Key Format ' + key);
-
-  return null;
-};
-// should be a helper
-function buffertoByteArray(value) {
-  return BigInteger.fromBuffer(value).toByteArray();
-}
-// should be a helper
-// used locally and wallet-spender.js
-MyWallet.privateKeyStringToKey = function(value, format) {
-  var key_bytes = null;
-
-  if (format == 'base58') {
-    key_bytes = buffertoByteArray(Base58.decode(value));
-  } else if (format == 'base64') {
-    key_bytes = buffertoByteArray(new Buffer(value, 'base64'));
-  } else if (format == 'hex') {
-    key_bytes = buffertoByteArray(new Buffer(value, 'hex'));
-  } else if (format == 'mini') {
-    key_bytes = buffertoByteArray(parseMiniKey(value));
-  } else if (format == 'sipa') {
-    var tbytes = buffertoByteArray(Base58.decode(value));
-    tbytes.shift(); //extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
-    tbytes.shift();
-    key_bytes = tbytes.slice(0, tbytes.length - 4);
-
-  } else if (format == 'compsipa') {
-    var tbytes = buffertoByteArray(Base58.decode(value));
-    tbytes.shift(); //extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
-    tbytes.shift();
-    tbytes.pop();
-    key_bytes = tbytes.slice(0, tbytes.length - 4);
-  } else {
-    throw 'Unsupported Key Format';
-  }
-
-  return new ECKey(new BigInteger.fromByteArrayUnsigned(key_bytes), (format !== 'sipa'));
-};
-
-// used once
-// should be a helper
-function parseValueBitcoin(valueString) {
-  var valueString = valueString.toString();
-  // TODO: Detect other number formats (e.g. comma as decimal separator)
-  var valueComp = valueString.split('.');
-  var integralPart = valueComp[0];
-  var fractionalPart = valueComp[1] || "0";
-  while (fractionalPart.length < 8) fractionalPart += "0";
-  fractionalPart = fractionalPart.replace(/^0+/g, '');
-  var value = BigInteger.valueOf(parseInt(integralPart));
-  value = value.multiply(BigInteger.valueOf(100000000));
-  value = value.add(BigInteger.valueOf(parseInt(fractionalPart)));
-  return value;
-}
-// used iOS and mywallet
-MyWallet.precisionToSatoshiBN = function(x) {
-  return parseValueBitcoin(x).divide(BigInteger.valueOf(Math.pow(10, shared.sShift(shared.getBTCSymbol())).toString()));
 };

--- a/tests/transaction_spend_spec.js.coffee
+++ b/tests/transaction_spend_spec.js.coffee
@@ -146,7 +146,7 @@ describe "Transaction", ->
       tx = new Transaction(data.unspentMock, data.toMultiple, data.multipleAmounts, data.fee, data.from, null)
 
       privateKeyBase58 = data.privateKey
-      format = MyWallet.detectPrivateKeyFormat(privateKeyBase58)
+      format = Helpers.detectPrivateKeyFormat(privateKeyBase58)
       key = Helpers.privateKeyStringToKey(privateKeyBase58, format)
       key.pub.compressed = false;
       privateKeys = [key]
@@ -171,7 +171,7 @@ describe "Transaction", ->
       transaction = new Transaction(data.unspentMock, data.to, data.amount, data.fee, data.from, null)
 
       privateKeyBase58 = data.privateKey
-      format = MyWallet.detectPrivateKeyFormat(privateKeyBase58)
+      format = Helpers.detectPrivateKeyFormat(privateKeyBase58)
       key = Helpers.privateKeyStringToKey(privateKeyBase58, format)
       key.pub.compressed = false;
       privateKeys = [key]
@@ -184,7 +184,7 @@ describe "Transaction", ->
       transaction = new Transaction(data.unspentMock, data.to, data.amount, data.fee, data.from, null)
 
       privateKeyWIF = '5JfdACpmDbLk7jmjU6kuCdLNFgedL19RnbjZYENAEG8Ntto9zRc'
-      format = MyWallet.detectPrivateKeyFormat(privateKeyWIF)
+      format = Helpers.detectPrivateKeyFormat(privateKeyWIF)
       key = Helpers.privateKeyStringToKey(privateKeyWIF, format)
       privateKeys = [key]
 
@@ -204,7 +204,7 @@ describe "Transaction", ->
       transaction = new Transaction(data.unspentMock, data.to, data.amount, data.fee, data.from, null)
       transaction.listener = listener
       privateKeyBase58 = data.privateKey
-      format = MyWallet.detectPrivateKeyFormat(privateKeyBase58)
+      format = Helpers.detectPrivateKeyFormat(privateKeyBase58)
       key = Helpers.privateKeyStringToKey(privateKeyBase58, format)
       key.pub.compressed = false;
       privateKeys = [key]


### PR DESCRIPTION
This pull request will require some small changes on iOS and webwallet @jtormey , @woudini 

API CHANGES:

MyWallet.isValidateBIP39Mnemonic(m) --> Helpers.isValidBIP39Mnemonic(m)
MyWallet.isValidAddress(a) --> Helpers.isBitcoinAddress(a)
MyWallet.isValidPrivateKey --> Helpers.isValidPrivateKey  [this functions a little bit bizarre, do you need it justin?]
MyWallet.privateKeyStringToKey --> Helpers.privateKeyStringToKey
MyWallet.detectPrivateKeyFormat  --> Helpers.detectPrivateKeyFormat
MyWallet.precisionToSatoshiBN --> Helpers.precisionToSatoshiBN [not sure this needs to be on mywallet]
