### PR TITLE
Blockchain-settings-api fixes and tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -86,7 +86,8 @@ module.exports = function(karma) {
       'tests/wallet_transaction_spec.js.coffee',
       'tests/transaction_list_spec.js.coffee',
       'tests/wallet_crypto_spec.js.coffee',
-      'tests/wallet_signup_spec.js.coffee'
+      'tests/wallet_signup_spec.js.coffee',
+      'tests/blockchain_settings_api_spec.js.coffee'
     ]
   };
 

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -257,8 +257,8 @@ function enableReceiveNotifications(success, error) {
 }
 
 function enableEmailReceiveNotifications(success, error) {
-  assert(success, "Success callback required");
-  assert(error, "Error callback required");
+  assert(success && typeof(error) === "function", "Success callback required");
+  assert(error && typeof(error) === "function", "Error callback required");
 
   enableEmailNotifications(
     function() {
@@ -272,19 +272,19 @@ function enableEmailReceiveNotifications(success, error) {
 }
 
 function disableAllNotifications(success, error) {
-  assert(success, "Success callback required");
-  assert(error, "Error callback required");
+  assert(success && typeof(error) === "function", "Success callback required");
+  assert(error && typeof(error) === "function", "Error callback required");
 
   API.securePostCallbacks("wallet", {
     method : 'update-notifications-type',
     length: 1,
     payload: 0
   }).then(function(data) {
-    typeof(success) === "function" && success(data);
+    success(data);
   }).catch(function(data) {
     var response = data.responseText || 'Error Disabling Receive Notifications';
     WalletStore.sendEvent("msg", {type: "error", message: response});
-    typeof(error) === "function" &&  error();
+    error();
   });
 }
 

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -311,5 +311,7 @@ module.exports = {
   disableAllNotifications: disableAllNotifications,
   // for tests only
   enableEmailNotifications: enableEmailNotifications,
-  enableReceiveNotifications: enableReceiveNotifications
+  enableReceiveNotifications: enableReceiveNotifications,
+  updateAuthType: updateAuthType
+
 };

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -307,5 +307,8 @@ module.exports = {
   verifyMobile: verifyMobile,
   getActivityLogs: getActivityLogs,
   enableEmailReceiveNotifications: enableEmailReceiveNotifications,
-  disableAllNotifications: disableAllNotifications
+  disableAllNotifications: disableAllNotifications,
+  // for tests only
+  enableEmailNotifications: enableEmailNotifications,
+  enableReceiveNotifications: enableReceiveNotifications
 };

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -191,6 +191,7 @@ function verifyEmail(code, success, error) {
     WalletStore.sendEvent("msg", {type: "success", message: data});
     typeof(success) === "function" && success(data);
   }, function(data) {
+    WalletStore.sendEvent("msg", {type: "error", message: data});
     typeof(error) === "function" &&  error();
   });
 }

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -12,10 +12,8 @@ function get_account_info(success, error) {
     typeof(success) === "function" && success(data);
 
   }, function(data) {
-    if (data.responseText)
-      WalletStore.sendEvent("msg", {type: "error", message: data.responseText});
-    else
-      WalletStore.sendEvent("msg", {type: "error", message: 'Error Downloading Account Settings'});
+    var response = data.responseText || 'Error Downloading Account Settings';
+    WalletStore.sendEvent("msg", {type: "error", message: response});
 
     typeof(error) === "function" &&  error();
   });

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -38,7 +38,7 @@ function updateKV(method, value, success, error, extra) {
 }
 
 function update_API_access(enabled, success, error) {
-  updateKV('update-api-access-enabled', enabled ? 1 : 0, success, error);
+  updateKV('update-api-access-enabled', enabled ? true : false, success, error);
 }
 
 /**
@@ -67,7 +67,7 @@ function change_btc_currency(code, success, error) {
 }
 
 function update_tor_ip_block(enabled, success, error) {
-  updateKV('update-block-tor-ips', enabled, success, error);
+  updateKV('update-block-tor-ips', enabled ? true : false, success, error);
 }
 
 function isBadPasswordHint(value) {

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -72,36 +72,31 @@ function update_tor_ip_block(enabled, success, error) {
   updateKV('update-block-tor-ips', enabled, success, error);
 }
 
-function update_password_hint1(value, success, error) {
-  switch (true) {
-    case value.split('').some(function(c){return c.charCodeAt(0) > 255;}):
-      error(101); // invalid charset
-      break;
-    case (WalletStore.getPassword() === value):
-      error(102); // password hint cannot be main wallet pass
-      break;
-    case (MyWallet.wallet.isDoubleEncrypted && MyWallet.wallet.validateSecondPassword(value)):
-      error(103); // password hint cannot be second passord
-      break;
-    default:
-      updateKV('update-password-hint1', value, success, error);
+function isBadPasswordHint(value) {
+  if (value.split('').some(function(c){return c.charCodeAt(0) > 255;})) {
+    return 101; // invalid charset
+  } else if (WalletStore.getPassword() === value) {
+    return 102; // password hint cannot be main wallet pass
+  } else if (MyWallet.wallet.isDoubleEncrypted && MyWallet.wallet.validateSecondPassword(value)) {
+    return 103; // password hint cannot be second passord
+  } else {
+    return false;
   }
 }
 
+function update_password_hint1(value, success, error) {
+  assert(error && typeof(error) === "function", "Error callback required");
+
+  var isBad = isBadPasswordHint(value);
+  isBad ? error(isBad) : updateKV('update-password-hint1', value, success, error);
+}
+
 function update_password_hint2(value, success, error) {
-  switch (true) {
-    case value.split('').some(function(c){return c.charCodeAt(0) > 255;}):
-      error(101); // invalid charset
-      break;
-    case (WalletStore.getPassword() === value):
-      error(102); // password hint cannot be main wallet pass
-      break;
-    case (MyWallet.wallet.isDoubleEncrypted && MyWallet.wallet.validateSecondPassword(value)):
-      error(103); // password hint cannot be second passord
-      break;
-    default:
-      updateKV('update-password-hint2', value, success, error);
-  }
+  assert(error && typeof(error) === "function", "Error callback required");
+
+  var isBad = isBadPasswordHint(value);
+  isBad ? error(isBad) : updateKV('update-password-hint2', value, success, error);
+
 }
 
 function change_email(email, success, error) {

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -226,9 +226,9 @@ function enableEmailNotifications(success, error) {
     method : 'update-notifications-type',
     length: 1,
     payload: 1
-  }).then(function(data) {
+  }, function(data) {
     typeof(success) === "function" && success(data);
-  }).catch(function(data) {
+  }, function(data) {
     var response = data.responseText || 'Error Enabling Email Notifications';
     WalletStore.sendEvent("msg", {type: "error", message: response});
     typeof(error) === "function" &&  error();
@@ -240,9 +240,9 @@ function enableReceiveNotifications(success, error) {
     method : 'update-notifications-on',
     length: 1,
     payload: 2
-  }).then(function(data) {
+  }, function(data) {
     typeof(success) === "function" && success(data);
-  }).catch(function(data) {
+  }, function(data) {
     var response = data.responseText || 'Error Enabling Receive Notifications';
     WalletStore.sendEvent("msg", {type: "error", message: response});
     typeof(error) === "function" &&  error();
@@ -272,9 +272,9 @@ function disableAllNotifications(success, error) {
     method : 'update-notifications-type',
     length: 1,
     payload: 0
-  }).then(function(data) {
+  }, function(data) {
     success(data);
-  }).catch(function(data) {
+  }, function(data) {
     var response = data.responseText || 'Error Disabling Receive Notifications';
     WalletStore.sendEvent("msg", {type: "error", message: response});
     error();

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -266,7 +266,7 @@ function enableEmailReceiveNotifications(success, error) {
 }
 
 function disableAllNotifications(success, error) {
-  assert(success && typeof(error) === "function", "Success callback required");
+  assert(success && typeof(success) === "function", "Success callback required");
   assert(error && typeof(error) === "function", "Error callback required");
 
   API.securePostCallbacks("wallet", {

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -21,7 +21,7 @@ function get_account_info(success, error) {
   });
 }
 
-function updateKV(txt, method, value, success, error, extra) {
+function updateKV(method, value, success, error, extra) {
   if(typeof value == "string") {
     value = value.trim();
   }
@@ -40,7 +40,7 @@ function updateKV(txt, method, value, success, error, extra) {
 }
 
 function update_API_access(enabled, success, error) {
-  updateKV('Updating Api Access', 'update-api-access-enabled', enabled ? 1 : 0, success, error);
+  updateKV('update-api-access-enabled', enabled ? 1 : 0, success, error);
 }
 
 /**
@@ -49,27 +49,27 @@ function update_API_access(enabled, success, error) {
  * @param {function()} error error callback function
  */
 function update_IP_lock(ips, success, error) {
-  updateKV('Updating Locked Ip Addresses', 'update-ip-lock', ips, success, error);
+  updateKV('update-ip-lock', ips, success, error);
 }
 
 function update_IP_lock_on(enabled, success, error) {
-  updateKV('Updating IP Lock', 'update-ip-lock-on', enabled ? true : false, success, error);
+  updateKV('update-ip-lock-on', enabled ? true : false, success, error);
 }
 
 function change_language(language, success, error) {
-  updateKV('Updating Language', 'update-language', language, success, error);
+  updateKV('update-language', language, success, error);
 }
 
 function change_local_currency(code, success, error) {
-  updateKV('Updating Local Currency', 'update-currency', code, success, error);
+  updateKV('update-currency', code, success, error);
 }
 
 function change_btc_currency(code, success, error) {
-  updateKV('Updating BTC Currency', 'update-btc-currency', code, success, error);
+  updateKV('update-btc-currency', code, success, error);
 }
 
 function update_tor_ip_block(enabled, success, error) {
-  updateKV('Updating TOR ip block', 'update-block-tor-ips', enabled, success, error);
+  updateKV('update-block-tor-ips', enabled, success, error);
 }
 
 function update_password_hint1(value, success, error) {
@@ -84,7 +84,7 @@ function update_password_hint1(value, success, error) {
       error(103); // password hint cannot be second passord
       break;
     default:
-      updateKV('Updating Main Password Hint', 'update-password-hint1', value, success, error);
+      updateKV('update-password-hint1', value, success, error);
   }
 }
 
@@ -100,16 +100,16 @@ function update_password_hint2(value, success, error) {
       error(103); // password hint cannot be second passord
       break;
     default:
-      updateKV('Updating Logging Level', 'update-password-hint2', value, success, error);
+      updateKV('update-password-hint2', value, success, error);
   }
 }
 
 function change_email(email, success, error) {
-  updateKV('Updating Email', 'update-email', email, success, error);
+  updateKV('update-email', email, success, error);
 }
 
 function changeMobileNumber(val, success, error) {
-  updateKV('Updating Cell Number', 'update-sms', val, success, error);
+  updateKV('update-sms', val, success, error);
 }
 
 // Logging levels:
@@ -117,15 +117,15 @@ function changeMobileNumber(val, success, error) {
 // 1 - Log actions with hashed IP addresses
 // 2 - Log actions with IP addresses and user agents
 function updateLoggingLevel(val, success, error) {
-  updateKV('Updating Logging Level', 'update-logging-level', val, success, error);
+  updateKV('update-logging-level', val, success, error);
 }
 
 function toggleSave2FA(val, success, error) {
-  updateKV('Updating Save 2FA', 'update-never-save-auth-type', val ? true : false, success, error);
+  updateKV('update-never-save-auth-type', val ? true : false, success, error);
 }
 
 function updateAuthType(val, success, error) {
-  updateKV('Updating Two Factor Authentication', 'update-auth-type', val, function() {
+  updateKV('update-auth-type', val, function() {
     WalletStore.setRealAuthType(val);
     typeof(success) === "function" && success();
   }, error);
@@ -146,7 +146,6 @@ function setTwoFactorYubiKey(code, success, error) {
 
   // Tell the server about the YubiKey and then enable 2FA with it:
   updateKV(
-    'Configuring Yubikey',
     'update-yubikey',
     code,
     function() {
@@ -172,7 +171,7 @@ function setTwoFactorGoogleAuthenticator(success, error) {
 }
 
 function confirmTwoFactorGoogleAuthenticator(code, success, error) {
-  updateKV('Updating Two Factor Authentication', 'update-auth-type', 4, function() {
+  updateKV('update-auth-type', 4, function() {
     WalletStore.setRealAuthType(4);
     typeof(success) === "function" && success();
   }, error, '?code='+code);
@@ -185,7 +184,7 @@ function confirmTwoFactorGoogleAuthenticator(code, success, error) {
  * @param {function()} error Error callback function.
  */
 function resendEmailConfirmation(email, success, error) {
-  updateKV('Resend Email Confirmation', 'update-email', email, success, error);
+  updateKV('update-email', email, success, error);
 }
 
 /**

--- a/tests/blockchain_settings_api_spec.js.coffee
+++ b/tests/blockchain_settings_api_spec.js.coffee
@@ -1,0 +1,564 @@
+proxyquire = require('proxyquireify')(require)
+
+MyWallet =
+  doubleEncrypted: false
+  wallet:
+    validateSecondPassword: (pass) -> pass == "second password"
+    isDoubleEncrypted: () -> MyWallet.doubleEncrypted
+
+API =
+  callFailWithResponseText: false
+  callFailWithoutResponseText: false
+  securePostCallbacks: (endpoint, data, success, error) ->
+    if API.callFailWithoutResponseText
+      error('call failed')
+    else if API.callFailWithResponseText
+      error({responseText: 'call failed'})
+    else
+      success('call succeeded')
+
+WalletStore =
+  sendEvent: () ->
+  getPassword: () -> "password"
+  setRealAuthType: () ->
+
+stubs = {
+  './wallet.js': MyWallet,
+  './api': API,
+  './wallet-store.js': WalletStore
+}
+
+SettingsAPI = proxyquire('../src/blockchain-settings-api', stubs)
+
+describe "SettingsAPI", ->
+
+  observers =
+    success: () ->
+    error: () ->
+
+  beforeEach ->
+    spyOn(WalletStore, "sendEvent")
+    spyOn(WalletStore, "setRealAuthType")
+    spyOn(API, "securePostCallbacks").and.callThrough()
+    spyOn(observers, "success").and.callThrough()
+    spyOn(observers, "error").and.callThrough()
+
+
+  describe "boolean settings", ->
+    booleanSettingsField = [
+      {
+        func: "update_API_access",
+        endpoint: "update-api-access-enabled"
+      },
+      {
+        func: "update_IP_lock_on",
+        endpoint: "update-ip-lock-on"
+      },
+      {
+        func: "update_tor_ip_block",
+        endpoint: "update-block-tor-ips"
+      },
+      {
+        func: "toggleSave2FA",
+        endpoint: "update-never-save-auth-type"
+      }
+    ]
+
+
+    booleanSettingsField.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should work without any callbacks", ->
+          SettingsAPI[setting.func](true)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 4, payload: 'true', method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: setting.endpoint + '-success: call succeeded'})
+
+        it "should work with callbacks", ->
+          SettingsAPI[setting.func](false, observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 5, payload: 'false', method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: setting.endpoint + '-success: call succeeded'})
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func](1, observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 4, payload: 'true', method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: setting.endpoint + '-error: call failed'})
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+
+  describe "string settings", ->
+    stringSettingsField = [
+      {
+        func: "change_language",
+        endpoint: "update-language"
+      },
+      {
+        func: "update_IP_lock",
+        endpoint: "update-ip-lock"
+      },
+      {
+        func: "change_local_currency",
+        endpoint: "update-currency"
+      },
+      {
+        func: "change_btc_currency",
+        endpoint: "update-btc-currency"
+      },
+      {
+        func: "change_email",
+        endpoint: "update-email"
+      },
+      {
+        func: "changeMobileNumber",
+        endpoint: "update-sms"
+      },
+      {
+        func: "resendEmailConfirmation",
+        endpoint: "update-email"
+      }
+    ]
+
+
+    stringSettingsField.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should work without any callbacks", ->
+          SettingsAPI[setting.func]("string")
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 6, payload: 'string', method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: setting.endpoint + '-success: call succeeded'})
+
+        it "should work with callbacks", ->
+          SettingsAPI[setting.func]("string", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 6, payload: 'string', method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: setting.endpoint + '-success: call succeeded'})
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func]("string", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 6, payload: 'string', method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: setting.endpoint + '-error: call failed'})
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+
+  describe "code verification settings", ->
+    codeFields = [
+      {
+        func: "verifyMobile",
+        endpoint: "verify-sms"
+      },
+      {
+        func: "verifyEmail",
+        endpoint: "verify-email"
+      }
+    ]
+
+
+    codeFields.forEach (setting) ->
+      ['asder', 'sfdsrsetertetrte'].forEach (code) ->
+        describe "#{setting.func} with code #{code}", ->
+
+          it "should work with callbacks", ->
+            SettingsAPI[setting.func](code, observers.success, observers.error)
+
+            expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: code.length, payload: code, method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+            expect(observers.success).toHaveBeenCalled()
+            expect(observers.error).not.toHaveBeenCalled()
+
+          it "should fail if the API call fails", ->
+            API.callFailWithoutResponseText = true
+            SettingsAPI[setting.func](code, observers.success, observers.error)
+
+            expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: code.length, payload: code, method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+            expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'call failed'})
+            expect(observers.success).not.toHaveBeenCalled()
+            expect(observers.error).toHaveBeenCalled()
+
+  describe "getters", ->
+    getterFields = [
+      {
+        func: "getActivityLogs",
+        endpoint: "list-logs",
+        errorMessage: 'Error Downloading Activity Logs'
+      },
+      {
+        func: "get_account_info",
+        endpoint: "get-info",
+        errorMessage: 'Error Downloading Account Settings'
+      }
+    ]
+
+
+    getterFields.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should work without callbacks", ->
+          SettingsAPI[setting.func]()
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : setting.endpoint, format: 'json' }, jasmine.anything(), jasmine.anything())
+
+        it "should work with callbacks", ->
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : setting.endpoint, format: 'json' }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : setting.endpoint, format: 'json' }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: setting.errorMessage})
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+
+        it "should fail with error message if the API call fails with an error message", ->
+          API.callFailWithResponseText = true
+
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : setting.endpoint, format: 'json' }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'call failed'})
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+
+  describe "custom settings", ->
+    customSettingsFields = [
+      {
+        func: "disableAllNotifications",
+        endpoint: "update-notifications-type",
+        length: 1,
+        payload: 0,
+        errorMessage: 'Error Disabling Receive Notifications'
+      },
+      {
+        func: "enableReceiveNotifications",
+        endpoint: "update-notifications-on",
+        length: 1,
+        payload: 2,
+        errorMessage: 'Error Enabling Receive Notifications'
+      },
+      {
+        func: "enableEmailNotifications",
+        endpoint: "update-notifications-type",
+        length: 1,
+        payload: 1,
+        errorMessage: 'Error Enabling Email Notifications'
+      }
+    ]
+
+
+    customSettingsFields.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should work with callbacks", ->
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: setting.length, payload: setting.payload, method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: setting.length, payload: setting.payload, method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: setting.errorMessage})
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+
+        it "should fail with error message if the API call fails with an error message", ->
+          API.callFailWithResponseText = true
+
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: setting.length, payload: setting.payload, method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'call failed'})
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+
+  describe "password hints", ->
+    passwordHintFields = [
+      {
+        func: "update_password_hint1",
+        endpoint: "update-password-hint1"
+      },
+      {
+        func: "update_password_hint2",
+        endpoint: "update-password-hint2"
+      }
+    ]
+
+    passwordHintFields.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should not work without error callback", ->
+          expect(() -> SettingsAPI[setting.func]("hint", observers.success)).toThrow()
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func]("hint", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 4, payload: "hint", method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: setting.endpoint + '-error: call failed'})
+
+        it "should fail if the hint is not extended ascii", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func]("hįnt", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).not.toHaveBeenCalled()
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalledWith(101)
+          expect(WalletStore.sendEvent).not.toHaveBeenCalled()
+
+        it "should fail if the hint is the same as the password", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func]("password", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).not.toHaveBeenCalled()
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalledWith(102)
+          expect(WalletStore.sendEvent).not.toHaveBeenCalled()
+
+        it "should fail if the hint is the same as the second password", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func]("second password", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).not.toHaveBeenCalled()
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalledWith(103)
+          expect(WalletStore.sendEvent).not.toHaveBeenCalled()
+
+        it "should work otherwise", ->
+          SettingsAPI[setting.func]("hint", observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 4, payload: "hint", method : setting.endpoint }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: setting.endpoint + '-success: call succeeded'})
+
+  describe "auth types", ->
+    authTypeFields = [
+      {
+        func: "setTwoFactorEmail",
+        authType: 2
+      },
+      {
+        func: "unsetTwoFactor",
+        authType: 0
+      },
+      {
+        func: "setTwoFactorSMS",
+        authType: 5
+      },
+    ]
+
+    authTypeFields.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should work without callbacks", ->
+          SettingsAPI[setting.func]()
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-auth-type", payload: '' + setting.authType, length: 1 }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-auth-type-success: call succeeded'})
+          expect(WalletStore.setRealAuthType).toHaveBeenCalledWith(setting.authType)
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-auth-type", payload: '' + setting.authType, length: 1 }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'update-auth-type-error: call failed'})
+
+        it "should work with callbacks", ->
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-auth-type", payload: '' + setting.authType, length: 1 }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-auth-type-success: call succeeded'})
+          expect(WalletStore.setRealAuthType).toHaveBeenCalledWith(setting.authType)
+
+  describe "confirmTwoFactorGoogleAuthenticator", ->
+
+    it "should work without callbacks", ->
+      SettingsAPI.confirmTwoFactorGoogleAuthenticator("abc121")
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet?code=abc121", { method : "update-auth-type", payload: '4', length: 1 }, jasmine.anything(), jasmine.anything())
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-auth-type-success: call succeeded'})
+      expect(WalletStore.setRealAuthType).toHaveBeenCalledWith(4)
+
+    it "should fail if the API call fails", ->
+      API.callFailWithoutResponseText = true
+      SettingsAPI.confirmTwoFactorGoogleAuthenticator("abc121", observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet?code=abc121", { method : "update-auth-type", payload: '4', length: 1 }, jasmine.anything(), jasmine.anything())
+      expect(observers.success).not.toHaveBeenCalled()
+      expect(observers.error).toHaveBeenCalled()
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'update-auth-type-error: call failed'})
+
+    it "should work with callbacks", ->
+      SettingsAPI.confirmTwoFactorGoogleAuthenticator("abc121", observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet?code=abc121", { method : "update-auth-type", payload: '4', length: 1 }, jasmine.anything(), jasmine.anything())
+      expect(observers.success).toHaveBeenCalled()
+      expect(observers.error).not.toHaveBeenCalled()
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-auth-type-success: call succeeded'})
+      expect(WalletStore.setRealAuthType).toHaveBeenCalledWith(4)
+
+  describe "auth types", ->
+    authTypeFields = [
+      {
+        func: "setTwoFactorEmail",
+        authType: 2
+      },
+      {
+        func: "unsetTwoFactor",
+        authType: 0
+      },
+      {
+        func: "setTwoFactorSMS",
+        authType: 5
+      },
+    ]
+
+    authTypeFields.forEach (setting) ->
+      describe "#{setting.func}", ->
+
+        it "should work without callbacks", ->
+          SettingsAPI[setting.func]()
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-auth-type", payload: '' + setting.authType, length: 1 }, jasmine.anything(), jasmine.anything())
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-auth-type-success: call succeeded'})
+          expect(WalletStore.setRealAuthType).toHaveBeenCalledWith(setting.authType)
+
+        it "should fail if the API call fails", ->
+          API.callFailWithoutResponseText = true
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-auth-type", payload: '' + setting.authType, length: 1 }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).not.toHaveBeenCalled()
+          expect(observers.error).toHaveBeenCalled()
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'update-auth-type-error: call failed'})
+
+        it "should work with callbacks", ->
+          SettingsAPI[setting.func](observers.success, observers.error)
+
+          expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-auth-type", payload: '' + setting.authType, length: 1 }, jasmine.anything(), jasmine.anything())
+          expect(observers.success).toHaveBeenCalled()
+          expect(observers.error).not.toHaveBeenCalled()
+          expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-auth-type-success: call succeeded'})
+          expect(WalletStore.setRealAuthType).toHaveBeenCalledWith(setting.authType)
+
+  describe "enableEmailReceiveNotifications", ->
+
+    it "shouldn't work without callbacks", ->
+      expect(() -> SettingsAPI.enableEmailReceiveNotifications()).toThrow()
+
+    it "shouldn't work without error callback", ->
+      expect(() -> SettingsAPI.enableEmailReceiveNotifications(observers.success)).toThrow()
+
+    it "should work with both callbacks set", ->
+      SettingsAPI.enableEmailReceiveNotifications(observers.success, observers.error)
+
+      expect(observers.success).toHaveBeenCalled()
+      expect(observers.error).not.toHaveBeenCalled()
+      expect(API.securePostCallbacks).toHaveBeenCalledTimes(2)
+
+    it "should fail if any API call fails", ->
+      API.callFailWithoutResponseText = true
+      SettingsAPI.enableEmailReceiveNotifications(observers.success, observers.error)
+
+      expect(observers.success).not.toHaveBeenCalled()
+      expect(observers.error).toHaveBeenCalled()
+      expect(WalletStore.sendEvent).toHaveBeenCalledTimes(1)
+
+  describe "setTwoFactorGoogleAuthenticator", ->
+
+    it "should work without callbacks", ->
+      SettingsAPI.setTwoFactorGoogleAuthenticator()
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method: 'generate-google-secret' }, jasmine.anything(), jasmine.anything())
+
+    it "should work with callbacks", ->
+      SettingsAPI.setTwoFactorGoogleAuthenticator(observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method: 'generate-google-secret' }, jasmine.anything(), jasmine.anything())
+      expect(observers.success).toHaveBeenCalled()
+      expect(observers.error).not.toHaveBeenCalled()
+
+    it "should fail with error message if the API call fails with an error message", ->
+      API.callFailWithResponseText = true
+
+      SettingsAPI.setTwoFactorGoogleAuthenticator(observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method: 'generate-google-secret' }, jasmine.anything(), jasmine.anything())
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'call failed'})
+      expect(observers.success).not.toHaveBeenCalled()
+      expect(observers.error).toHaveBeenCalled()
+
+  describe "setTwoFactorYubiKey", ->
+
+    it "should not work without callbacks", ->
+      expect(() -> SettingsAPI.setTwoFactorYubiKey("cdsfe")).toThrow()
+
+    it "should work with callbacks", ->
+      SettingsAPI.setTwoFactorYubiKey("cdsfd", observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledTimes(2)
+      expect(observers.success).toHaveBeenCalled()
+      expect(observers.error).not.toHaveBeenCalled()
+
+    it "should fail with error message if the API call fails with an error message", ->
+      API.callFailWithoutResponseText = true
+
+      SettingsAPI.setTwoFactorYubiKey("cdsfd", observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { method : "update-yubikey", payload: 'cdsfd', length: 5 }, jasmine.anything(), jasmine.anything())
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'update-yubikey-error: call failed'})
+      expect(observers.success).not.toHaveBeenCalled()
+      expect(observers.error).toHaveBeenCalled()
+
+  describe "updateLoggingLevel", ->
+
+    it "should work without any callbacks", ->
+      SettingsAPI.updateLoggingLevel(0)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 1, payload: '0', method : 'update-logging-level' }, jasmine.anything(), jasmine.anything())
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-logging-level-success: call succeeded'})
+
+    it "should work with callbacks", ->
+      SettingsAPI.updateLoggingLevel(1, observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 1, payload: '1', method : 'update-logging-level' }, jasmine.anything(), jasmine.anything())
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-logging-level-success: call succeeded'})
+      expect(observers.success).toHaveBeenCalled()
+      expect(observers.error).not.toHaveBeenCalled()
+
+    it "should fail if the API call fails", ->
+      API.callFailWithoutResponseText = true
+      SettingsAPI.updateLoggingLevel(2, observers.success, observers.error)
+
+      expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 1, payload: '2', method : 'update-logging-level' }, jasmine.anything(), jasmine.anything())
+      expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'update-logging-level-error: call failed'})
+      expect(observers.success).not.toHaveBeenCalled()
+      expect(observers.error).toHaveBeenCalled()
+
+  afterEach ->
+    API.callFailWithoutResponseText = false
+    API.callFailWithResponseText = false
+    MyWallet.doubleEncrypted = false


### PR DESCRIPTION
The external API hasn't changed, only one internal function have had its signature changed.

Things to check before merging:

- update_API_access only sent 0 or 1, I updated it to true and false for coherence sake. We should check that the backend will understand the new requests.
- Same idea for update_tor_ip_block, I restrained the values sent to true or false

@Sjors you might know if this break the calls or not