### PR TITLE
Refactor Import Export

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -6,7 +6,7 @@ module.exports = (grunt) ->
     clean:
       build: ["build"]
       dist: ["dist"]
-      test: ["coverage"]
+      test: ["coverage", "coverage-lcov"]
       testjs: ["tests/*js"]
       shrinkwrap: ["npm-shrinkwrap.*"]
       node_modules: ["node_modules"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JavaScript Model for Blockchain.info wallet.
 
-## Install
+## Build
 
 ```sh
 npm install
@@ -29,12 +29,6 @@ Clean generated files:
 
 ```sh
 grunt clean
-```
-
-Remove all installed dependencies:
-
-```sh
-rm -rf node_modules/
 ```
 
 ## Getting Started

--- a/src/address.js
+++ b/src/address.js
@@ -188,17 +188,15 @@ Address.fromString = function (keyOrAddr, label, bipPass){
         if (bipPass == undefined || bipPass === '') {
           return reject('needsBip38');
         }
-        ImportExport.parseBIP38toECKey(keyOrAddr, bipPass,
-          function (key) { resolve(Address.import(key, label));},
-          function ()    { reject('wrongBipPass'); },
-          function ()    { reject('importError');}
-        );
-      }
-      else if (okFormats.indexOf(format) > -1) {
+        ImportExport.parseBIP38toECKey(keyOrAddr, bipPass)
+            .then(function (result) { resolve(Address.import(result.key, label)); })
+            .catch(function (e) { reject(e); });
+      } else if (okFormats.indexOf(format) > -1) {
         var k = Helpers.privateKeyStringToKey(keyOrAddr, format);
         return resolve(Address.import(k, label));
+      } else {
+        reject('unknown key format');
       }
-      else { reject('unknown key format'); }
     }
   };
   return new Promise(asyncParse);

--- a/src/blockchain-socket.js
+++ b/src/blockchain-socket.js
@@ -36,7 +36,7 @@ BlockchainSocket.prototype.connect = function (onOpen, onMessage, onClose) {
     var connect = this.connectOnce.bind(this, onOpen, onMessage, onClose);
     if (!this.socket || this.socket.readyState === 3) connect();
   }.bind(this);
-  var pingSocket = function () { this.send('{\'op\':\'ping\'}'); }.bind(this);
+  var pingSocket = function () { this.send(this.msgPing()); }.bind(this);
   this.reconnect();
   this.reconnectInterval = setInterval(this.reconnect, 20000);
   this.pingInterval = setInterval(pingSocket, 30013);
@@ -60,5 +60,49 @@ BlockchainSocket.prototype.send = function (message) {
   var send = function () {this.socket.send(message); }.bind(this);
   if (this.socket && this.socket.readyState === 1) { send();}
 };
+
+BlockchainSocket.prototype.msgWalletSub = function (myGUID) {
+  if (myGUID == null) { return ""; }
+  var m = { op   : 'wallet_sub', guid : myGUID };
+  return JSON.stringify(m);
+};
+
+BlockchainSocket.prototype.msgBlockSub = function () {
+  var m = { op   : 'blocks_sub' };
+  return JSON.stringify(m);
+};
+
+BlockchainSocket.prototype.msgAddrSub = function (addresses) {
+  if (addresses == null) { return ""; }
+  var addressArray = Helpers.toArrayFormat(addresses);
+  var toMsg = function (address) {
+    var m = { op   : 'addr_sub', addr : address };
+    return JSON.stringify(m);
+  }
+  return addressArray.map(toMsg).reduce(Helpers.add, "");
+};
+
+BlockchainSocket.prototype.msgXPUBSub = function (xpubs) {
+  if (xpubs == null) { return ""; }
+  var xpubsArray = Helpers.toArrayFormat(xpubs);
+  var toMsg = function (myxpub) {
+    var m = { op   : 'xpub_sub', xpub : myxpub };
+    return JSON.stringify(m);
+  }
+  return xpubsArray.map(toMsg).reduce(Helpers.add, "");
+};
+
+BlockchainSocket.prototype.msgPing = function () {
+  var m = { op : 'ping'};
+  return JSON.stringify(m);
+};
+
+BlockchainSocket.prototype.msgOnOpen = function (guid, addresses, xpubs) {
+  return this.msgBlockSub() +
+         this.msgWalletSub(guid) +
+         this.msgAddrSub(addresses) +
+         this.msgXPUBSub(xpubs);
+};
+
 
 module.exports = BlockchainSocket;

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -477,7 +477,7 @@ Wallet.prototype.importLegacyAddress = function (addr, label, secPass, bipPass) 
       ad.encrypt(cipher).persist();
     }
     this._addresses[ad.address] = ad;
-    MyWallet.ws.send('{\'op\':\'addr_sub\', \'addr\':\'' + ad.address + '\'}');
+    MyWallet.ws.send(MyWallet.ws.msgAddrSub(ad.address));
     MyWallet.syncWallet();
     this.getHistory();
     return ad;
@@ -738,7 +738,7 @@ Wallet.prototype.newAccount = function (label, pw, hdwalletIndex, success, nosav
     cipher = WalletCrypto.cipherFunction.bind(undefined, pw, this._sharedKey, this._pbkdf2_iterations);
   }
   var newAccount = this._hd_wallets[index].newAccount(label, cipher).lastAccount;
-  MyWallet.listenToHDWalletAccount(newAccount.extendedPublicKey);
+  MyWallet.ws.send(MyWallet.ws.msgXPUBSub(newAccount.extendedPublicKey));
   if(!(nosave === true)) MyWallet.syncWallet();
   typeof(success) === 'function' && success();
   return newAccount;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -380,22 +380,21 @@ Helpers.privateKeyCorrespondsToAddress = function (address, priv, bipPass) {
       if (bipPass == undefined || bipPass === '') {
         return reject('needsBip38');
       }
-      ImportExport.parseBIP38toECKey(priv, bipPass,
-        function (key) { resolve(key);},
-        function ()    { reject('wrongBipPass'); },
-        function ()    { reject('importError');}
-      );
+
+      ImportExport.parseBIP38toECKey(priv, bipPass)
+          .then(function (result) { resolve(result.key); })
+          .catch(function (e) { reject(e); });
     }
     else if (okFormats.indexOf(format) > -1) {
       var k = Helpers.privateKeyStringToKey(priv, format);
       return resolve(k);
     }
     else { reject('unknown key format'); }
-  }
+  };
   var predicate = function(key){
     var a = key.pub.getAddress().toString();
     return a === address? Base58.encode(key.d.toBuffer(32)) : null;
-  }
+  };
   return new Promise(asyncParse).then(predicate);
 };
 

--- a/src/import-export.js
+++ b/src/import-export.js
@@ -6,379 +6,148 @@ var BigInteger = require('bigi');
 var Base58 = require('bs58');
 var Unorm = require('unorm');
 var WalletCrypto = require('./wallet-crypto');
+var Buffer = require('buffer').Buffer;
 
 var hash256 = Bitcoin.crypto.hash256;
 
 var ImportExport = new function () {
 
-  this.parseBIP38toECKey = function (base58Encrypted, passphrase, success, wrong_password, error) {
-    var hex;
+  this.parseBIP38toECKey = function (base58Encrypted, passphrase) {
 
-    // Unicode NFC normalization
-    passphrase = Unorm.nfc(passphrase);
+    return new Promise(function (resolve, reject) {
 
-    try {
-      hex = Base58.decode(base58Encrypted);
-    } catch (e) {
-      error('Invalid Private Key');
-      return;
-    }
 
-    if (hex.length != 43) {
-      error('Invalid Private Key');
-      return;
-    } else if (hex[0] != 0x01) {
-      error('Invalid Private Key');
-      return;
-    }
+      var hex;
 
-    var expChecksum = hex.slice(-4);
-    hex = hex.slice(0, -4);
+      // Unicode NFC normalization
+      passphrase = Unorm.nfc(passphrase);
 
-    var checksum = hash256(hex);
-
-    if (checksum[0] != expChecksum[0] || checksum[1] != expChecksum[1] || checksum[2] != expChecksum[2] || checksum[3] != expChecksum[3]) {
-      error('Invalid Private Key');
-      return;
-    }
-
-    var isCompPoint = false;
-    var isECMult = false;
-    var hasLotSeq = false;
-    if (hex[1] == 0x42) {
-      if (hex[2] == 0xe0) {
-        isCompPoint = true;
-      } else if (hex[2] != 0xc0) {
-        error('Invalid Private Key');
-        return;
-      }
-    } else if (hex[1] == 0x43) {
-      isECMult = true;
-      isCompPoint = (hex[2] & 0x20) != 0;
-      hasLotSeq = (hex[2] & 0x04) != 0;
-      if ((hex[2] & 0x24) != hex[2]) {
-        error('Invalid Private Key');
-        return;
-      }
-    } else {
-      error('Invalid Private Key');
-      return;
-    }
-
-    var decrypted;
-    var AES_opts = { mode: WalletCrypto.AES.ECB, padding: WalletCrypto.pad.NoPadding };
-
-    var verifyHashAndReturn = function () {
-      var tmpkey = new Bitcoin.ECKey(decrypted, isCompPoint);
-
-      var base58Address = tmpkey.pub.getAddress().toBase58Check();
-
-      checksum = hash256(base58Address);
-
-      if (checksum[0] != hex[3] || checksum[1] != hex[4] || checksum[2] != hex[5] || checksum[3] != hex[6]) {
-        wrong_password();
-        return;
+      try {
+        hex = Base58.decode(base58Encrypted);
+      } catch (e) {
+        return reject('Invalid Private Key');
       }
 
-      success(tmpkey, isCompPoint);
-    };
+      if (hex.length != 43) {
+        return reject('Invalid Private Key');
+      } else if (hex[0] != 0x01) {
+        return reject('Invalid Private Key');
+      }
 
-    if (!isECMult) {
-      var addresshash = Buffer(hex.slice(3, 7));
+      var expChecksum = hex.slice(-4);
+      hex = hex.slice(0, -4);
 
-      ImportExport.Crypto_scrypt(passphrase, addresshash, 16384, 8, 8, 64, function (derivedBytes) {
+      var checksum = hash256(hex);
 
-        var k = derivedBytes.slice(32, 32+32);
+      if (checksum[0] != expChecksum[0] || checksum[1] != expChecksum[1] || checksum[2] != expChecksum[2] || checksum[3] != expChecksum[3]) {
+        return reject('Invalid Private Key');
+      }
 
-        var decryptedBytes = WalletCrypto.AES.decrypt(Buffer(hex.slice(7, 7+32)), k, null, AES_opts);
-        for (var x = 0; x < 32; x++) { decryptedBytes[x] ^= derivedBytes[x]; }
-
-        decrypted = BigInteger.fromBuffer(decryptedBytes);
-
-        verifyHashAndReturn();
-      });
-    } else {
-      var ownerentropy = hex.slice(7, 7+8);
-      var ownersalt = Buffer(!hasLotSeq ? ownerentropy : ownerentropy.slice(0, 4));
-
-      ImportExport.Crypto_scrypt(passphrase, ownersalt, 16384, 8, 8, 32, function (prefactorA) {
-
-        var passfactor;
-
-        if (!hasLotSeq) {
-          passfactor = prefactorA;
-        } else {
-          var prefactorB = Buffer.concat([prefactorA, Buffer(ownerentropy)]);
-          passfactor = hash256(prefactorB);
+      var isCompPoint = false;
+      var isECMult = false;
+      var hasLotSeq = false;
+      if (hex[1] == 0x42) {
+        if (hex[2] == 0xe0) {
+          isCompPoint = true;
+        } else if (hex[2] != 0xc0) {
+          return reject('Invalid Private Key');
         }
-
-        var kp = new Bitcoin.ECKey(BigInteger.fromBuffer(passfactor));
-
-        var passpoint = kp.pub.toBuffer();
-
-        var encryptedpart2 = Buffer(hex.slice(23, 23+16));
-
-        var addresshashplusownerentropy = Buffer(hex.slice(3, 3+12));
-
-        ImportExport.Crypto_scrypt(passpoint, addresshashplusownerentropy, 1024, 1, 1, 64, function (derived) {
-          var k = derived.slice(32);
-
-          var unencryptedpart2Bytes = WalletCrypto.AES.decrypt(encryptedpart2, k, null, AES_opts);
-
-          for (var i = 0; i < 16; i++) { unencryptedpart2Bytes[i] ^= derived[i+16]; }
-
-          var encryptedpart1 = Buffer.concat([Buffer(hex.slice(15, 15+8)), Buffer(unencryptedpart2Bytes.slice(0, 0+8))]);
-
-          var unencryptedpart1Bytes = WalletCrypto.AES.decrypt(encryptedpart1, k, null, AES_opts);
-
-          for (var i = 0; i < 16; i++) { unencryptedpart1Bytes[i] ^= derived[i]; }
-
-          var seedb = Buffer.concat([Buffer(unencryptedpart1Bytes.slice(0, 0+16)), Buffer(unencryptedpart2Bytes.slice(8, 8+8))]);
-
-          var factorb = hash256(seedb);
-
-          // secp256k1: N
-          var N = BigInteger.fromHex('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141');
-
-          decrypted = BigInteger.fromBuffer(passfactor).multiply(BigInteger.fromBuffer(factorb)).remainder(N);
-
-          verifyHashAndReturn();
-        });
-      });
-    }
-  };
-
-
-  var MAX_VALUE = 2147483647;
-  var workerUrl = null;
-
-  this.Crypto_scrypt = function (passwd, salt, N, r, p, dkLen, callback) {
-    if (N == 0 || (N & (N - 1)) != 0) throw Error('N must be > 0 and a power of 2');
-
-    if (N > MAX_VALUE / 128 / r) throw Error('Parameter N is too large');
-    if (r > MAX_VALUE / 128 / p) throw Error('Parameter r is too large');
-
-    if(!Buffer.isBuffer(passwd)) {
-      passwd = new Buffer(passwd, 'utf8');
-    }
-
-    if(!Buffer.isBuffer(salt)) {
-      salt = new Buffer(salt, 'utf8');
-    }
-
-    var B = WalletCrypto.pbkdf2(passwd, salt, 1, (p * 128 * r), WalletCrypto.algo.SHA256);
-
-    // Called in Firefox and IE which don't support Blob web workers with CSP enabled.
-    window.setTimeout(function () {
-      scryptCore();
-      var ret = WalletCrypto.pbkdf2(passwd, B, 1, dkLen, WalletCrypto.algo.SHA256);
-
-      callback(ret);
-    }, 0);
-    // }
-
-    // using this function to enclose everything needed to create a worker (but also invokable directly for synchronous use)
-    function scryptCore () {
-      var XY = [], V = [];
-
-      if (typeof B === 'undefined') {
-        onmessage = function (event) {
-          var data = event.data;
-          var N = data[0], r = data[1], p = data[2], B = data[3], i = data[4];
-
-          var Bslice = [];
-          arraycopy32(B, i * 128 * r, Bslice, 0, 128 * r);
-          smix(Bslice, 0, r, N, V, XY);
-
-          postMessage([i, Bslice]);
-        };
+      } else if (hex[1] == 0x43) {
+        isECMult = true;
+        isCompPoint = (hex[2] & 0x20) != 0;
+        hasLotSeq = (hex[2] & 0x04) != 0;
+        if ((hex[2] & 0x24) != hex[2]) {
+          return reject('Invalid Private Key');
+        }
       } else {
-        for(var i = 0; i < p; i++) {
-          smix(B, i * 128 * r, r, N, V, XY);
-        }
+        return reject('Invalid Private Key');
       }
 
-      function smix (B, Bi, r, N, V, XY) {
-        var Xi = 0;
-        var Yi = 128 * r;
-        var i;
+      var decrypted;
+      var AES_opts = { mode: WalletCrypto.AES.ECB, padding: WalletCrypto.pad.NoPadding };
 
-        arraycopy32(B, Bi, XY, Xi, Yi);
+      var verifyHashAndReturn = function () {
+        var tmpkey = new Bitcoin.ECKey(decrypted, isCompPoint);
 
-        for (i = 0; i < N; i++) {
-          arraycopy32(XY, Xi, V, i * Yi, Yi);
-          blockmix_salsa8(XY, Xi, Yi, r);
+        var base58Address = tmpkey.pub.getAddress().toBase58Check();
+
+        checksum = hash256(base58Address);
+
+        if (checksum[0] != hex[3] || checksum[1] != hex[4] || checksum[2] != hex[5] || checksum[3] != hex[6]) {
+          return reject('wrongBipPass');
         }
 
-        for (i = 0; i < N; i++) {
-          var j = integerify(XY, Xi, r) & (N - 1);
-          blockxor(V, j * Yi, XY, Xi, Yi);
-          blockmix_salsa8(XY, Xi, Yi, r);
-        }
+        return resolve({
+          key: tmpkey,
+          compression: isCompPoint
+        });
+      };
 
-        arraycopy32(XY, Xi, B, Bi, Yi);
+      if (!isECMult) {
+        var addresshash = Buffer(hex.slice(3, 7));
+
+        WalletCrypto.scrypt(passphrase, addresshash, 16384, 8, 8, 64, function (derivedBytes) {
+
+          var k = derivedBytes.slice(32, 32+32);
+
+          var decryptedBytes = WalletCrypto.AES.decrypt(Buffer(hex.slice(7, 7+32)), k, null, AES_opts);
+          for (var x = 0; x < 32; x++) { decryptedBytes[x] ^= derivedBytes[x]; }
+
+          decrypted = BigInteger.fromBuffer(decryptedBytes);
+
+          return verifyHashAndReturn();
+        });
+      } else {
+        var ownerentropy = hex.slice(7, 7+8);
+        var ownersalt = Buffer(!hasLotSeq ? ownerentropy : ownerentropy.slice(0, 4));
+
+        WalletCrypto.scrypt(passphrase, ownersalt, 16384, 8, 8, 32, function (prefactorA) {
+
+          var passfactor;
+
+          if (!hasLotSeq) {
+            passfactor = prefactorA;
+          } else {
+            var prefactorB = Buffer.concat([prefactorA, Buffer(ownerentropy)]);
+            passfactor = hash256(prefactorB);
+          }
+
+          var kp = new Bitcoin.ECKey(BigInteger.fromBuffer(passfactor));
+
+          var passpoint = kp.pub.toBuffer();
+
+          var encryptedpart2 = Buffer(hex.slice(23, 23+16));
+
+          var addresshashplusownerentropy = Buffer(hex.slice(3, 3+12));
+
+          WalletCrypto.scrypt(passpoint, addresshashplusownerentropy, 1024, 1, 1, 64, function (derived) {
+            var k = derived.slice(32);
+
+            var unencryptedpart2Bytes = WalletCrypto.AES.decrypt(encryptedpart2, k, null, AES_opts);
+
+            for (var i = 0; i < 16; i++) { unencryptedpart2Bytes[i] ^= derived[i+16]; }
+
+            var encryptedpart1 = Buffer.concat([Buffer(hex.slice(15, 15+8)), Buffer(unencryptedpart2Bytes.slice(0, 0+8))]);
+
+            var unencryptedpart1Bytes = WalletCrypto.AES.decrypt(encryptedpart1, k, null, AES_opts);
+
+            for (var i = 0; i < 16; i++) { unencryptedpart1Bytes[i] ^= derived[i]; }
+
+            var seedb = Buffer.concat([Buffer(unencryptedpart1Bytes.slice(0, 0+16)), Buffer(unencryptedpart2Bytes.slice(8, 8+8))]);
+
+            var factorb = hash256(seedb);
+
+            // secp256k1: N
+            var N = BigInteger.fromHex('fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141');
+
+            decrypted = BigInteger.fromBuffer(passfactor).multiply(BigInteger.fromBuffer(factorb)).remainder(N);
+
+            return verifyHashAndReturn();
+          });
+        });
       }
-
-      function blockmix_salsa8 (BY, Bi, Yi, r) {
-        var X = [];
-        var i;
-
-        arraycopy32(BY, Bi + (2 * r - 1) * 64, X, 0, 64);
-
-        for (i = 0; i < 2 * r; i++) {
-          blockxor(BY, i * 64, X, 0, 64);
-          salsa20_8(X);
-          arraycopy32(X, 0, BY, Yi + (i * 64), 64);
-        }
-
-        for (i = 0; i < r; i++) {
-          arraycopy32(BY, Yi + (i * 2) * 64, BY, Bi + (i * 64), 64);
-        }
-
-        for (i = 0; i < r; i++) {
-          arraycopy32(BY, Yi + (i * 2 + 1) * 64, BY, Bi + (i + r) * 64, 64);
-        }
-      }
-
-      function R (a, b) {
-        return (a << b) | (a >>> (32 - b));
-      }
-
-      function salsa20_8 (B) {
-        var B32 = new Array(32);
-        var x   = new Array(32);
-        var i;
-
-        for (i = 0; i < 16; i++) {
-          B32[i]  = (B[i * 4 + 0] & 0xff) << 0;
-          B32[i] |= (B[i * 4 + 1] & 0xff) << 8;
-          B32[i] |= (B[i * 4 + 2] & 0xff) << 16;
-          B32[i] |= (B[i * 4 + 3] & 0xff) << 24;
-        }
-
-        arraycopy(B32, 0, x, 0, 16);
-
-        for (i = 8; i > 0; i -= 2) {
-          x[ 4] ^= R(x[ 0]+x[12], 7);  x[ 8] ^= R(x[ 4]+x[ 0], 9);
-          x[12] ^= R(x[ 8]+x[ 4],13);  x[ 0] ^= R(x[12]+x[ 8],18);
-          x[ 9] ^= R(x[ 5]+x[ 1], 7);  x[13] ^= R(x[ 9]+x[ 5], 9);
-          x[ 1] ^= R(x[13]+x[ 9],13);  x[ 5] ^= R(x[ 1]+x[13],18);
-          x[14] ^= R(x[10]+x[ 6], 7);  x[ 2] ^= R(x[14]+x[10], 9);
-          x[ 6] ^= R(x[ 2]+x[14],13);  x[10] ^= R(x[ 6]+x[ 2],18);
-          x[ 3] ^= R(x[15]+x[11], 7);  x[ 7] ^= R(x[ 3]+x[15], 9);
-          x[11] ^= R(x[ 7]+x[ 3],13);  x[15] ^= R(x[11]+x[ 7],18);
-          x[ 1] ^= R(x[ 0]+x[ 3], 7);  x[ 2] ^= R(x[ 1]+x[ 0], 9);
-          x[ 3] ^= R(x[ 2]+x[ 1],13);  x[ 0] ^= R(x[ 3]+x[ 2],18);
-          x[ 6] ^= R(x[ 5]+x[ 4], 7);  x[ 7] ^= R(x[ 6]+x[ 5], 9);
-          x[ 4] ^= R(x[ 7]+x[ 6],13);  x[ 5] ^= R(x[ 4]+x[ 7],18);
-          x[11] ^= R(x[10]+x[ 9], 7);  x[ 8] ^= R(x[11]+x[10], 9);
-          x[ 9] ^= R(x[ 8]+x[11],13);  x[10] ^= R(x[ 9]+x[ 8],18);
-          x[12] ^= R(x[15]+x[14], 7);  x[13] ^= R(x[12]+x[15], 9);
-          x[14] ^= R(x[13]+x[12],13);  x[15] ^= R(x[14]+x[13],18);
-        }
-
-        for (i = 0; i < 16; ++i) B32[i] = x[i] + B32[i];
-
-        for (i = 0; i < 16; i++) {
-          var bi = i * 4;
-          B[bi + 0] = (B32[i] >> 0  & 0xff);
-          B[bi + 1] = (B32[i] >> 8  & 0xff);
-          B[bi + 2] = (B32[i] >> 16 & 0xff);
-          B[bi + 3] = (B32[i] >> 24 & 0xff);
-        }
-      }
-
-      function blockxor (S, Si, D, Di, len) {
-        var i = len>>6;
-        while (i--) {
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-        }
-      }
-
-      function integerify (B, bi, r) {
-        var n;
-
-        bi += (2 * r - 1) * 64;
-
-        n  = (B[bi + 0] & 0xff) << 0;
-        n |= (B[bi + 1] & 0xff) << 8;
-        n |= (B[bi + 2] & 0xff) << 16;
-        n |= (B[bi + 3] & 0xff) << 24;
-
-        return n;
-      }
-
-      function arraycopy (src, srcPos, dest, destPos, length) {
-        while (length-- ){
-          dest[destPos++] = src[srcPos++];
-        }
-      }
-
-      function arraycopy32 (src, srcPos, dest, destPos, length) {
-        var i = length>>5;
-        while(i--) {
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-        }
-      }
-    } // scryptCore
+    });
   };
-
 };
 
 module.exports = ImportExport;

--- a/src/payment.js
+++ b/src/payment.js
@@ -353,7 +353,7 @@ Payment.publish = function () {
     };
 
     var handleError = function (e) {
-      throw e.message || e.responseText;
+      throw e.message || e.responseText || e;
     };
 
     var getValue = function (coin) {return coin.value;};

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -1,8 +1,11 @@
 'use strict';
 
-var crypto  = require('crypto')
-  , assert  = require('assert')
-  , sjcl    = require('sjcl');
+var crypto  = require('crypto');
+var assert  = require('assert');
+var sjcl    = require('sjcl');
+var Buffer = require('buffer').Buffer;
+var Helpers    = require('./helpers');
+
 
 var SUPPORTED_ENCRYPTION_VERSION = 3
   , SALT_BYTES = 16
@@ -304,6 +307,225 @@ function sha256 (data) {
   return crypto.createHash('sha256').update(data).digest();
 }
 
+function scrypt (passwd, salt, N, r, p, dkLen, callback) {
+  var MAX_VALUE = 2147483647;
+
+  if (!Helpers.isPositiveInteger(r) || r == 0) { throw Error('Parameter r must be a positive integer'); }
+
+  if (!Helpers.isPositiveInteger(p) || p == 0) { throw Error('Parameter p must be a positive integer'); }
+
+  if (!Helpers.isPositiveInteger(N) || N == 0 || (N & (N - 1)) != 0) { throw Error('N must be > 0 and a power of 2'); }
+
+  if (N > MAX_VALUE / 128 / r) { throw Error('Parameter N is too large'); }
+
+  if (r > MAX_VALUE / 128 / p) { throw Error('Parameter r is too large'); }
+
+  if (!Helpers.isPositiveInteger(dkLen) || dkLen == 0 || dkLen > MAX_VALUE * 32) { throw Error('Parameter dkLen must be ≤ (2^32− 1) * hLen'); }
+
+  if(!Buffer.isBuffer(passwd)) {
+    passwd = new Buffer(passwd, 'utf8');
+  }
+
+  if(!Buffer.isBuffer(salt)) {
+    salt = new Buffer(salt, 'utf8');
+  }
+
+  var B = pbkdf2(passwd, salt, 1, (p * 128 * r), ALGO.SHA256);
+
+  scryptCore();
+  var ret = pbkdf2(passwd, B, 1, dkLen, ALGO.SHA256);
+
+  callback(ret);
+
+  // using this function to enclose everything needed to create a worker (but also invokable directly for synchronous use)
+  function scryptCore () {
+    var XY = [], V = [];
+
+    for(var i = 0; i < p; i++) {
+      smix(B, i * 128 * r, r, N, V, XY);
+    }
+
+    function smix (B, Bi, r, N, V, XY) {
+      var Xi = 0;
+      var Yi = 128 * r;
+      var i;
+
+      arraycopy32(B, Bi, XY, Xi, Yi);
+
+      for (i = 0; i < N; i++) {
+        arraycopy32(XY, Xi, V, i * Yi, Yi);
+        blockmix_salsa8(XY, Xi, Yi, r);
+      }
+
+      for (i = 0; i < N; i++) {
+        var j = integerify(XY, Xi, r) & (N - 1);
+        blockxor(V, j * Yi, XY, Xi, Yi);
+        blockmix_salsa8(XY, Xi, Yi, r);
+      }
+
+      arraycopy32(XY, Xi, B, Bi, Yi);
+    }
+
+    function blockmix_salsa8 (BY, Bi, Yi, r) {
+      var X = [];
+      var i;
+
+      arraycopy32(BY, Bi + (2 * r - 1) * 64, X, 0, 64);
+
+      for (i = 0; i < 2 * r; i++) {
+        blockxor(BY, i * 64, X, 0, 64);
+        salsa20_8(X);
+        arraycopy32(X, 0, BY, Yi + (i * 64), 64);
+      }
+
+      for (i = 0; i < r; i++) {
+        arraycopy32(BY, Yi + (i * 2) * 64, BY, Bi + (i * 64), 64);
+      }
+
+      for (i = 0; i < r; i++) {
+        arraycopy32(BY, Yi + (i * 2 + 1) * 64, BY, Bi + (i + r) * 64, 64);
+      }
+    }
+
+    function R (a, b) {
+      return (a << b) | (a >>> (32 - b));
+    }
+
+    function salsa20_8 (B) {
+      var B32 = new Array(32);
+      var x   = new Array(32);
+      var i;
+
+      for (i = 0; i < 16; i++) {
+        B32[i]  = (B[i * 4 + 0] & 0xff) << 0;
+        B32[i] |= (B[i * 4 + 1] & 0xff) << 8;
+        B32[i] |= (B[i * 4 + 2] & 0xff) << 16;
+        B32[i] |= (B[i * 4 + 3] & 0xff) << 24;
+      }
+
+      arraycopy(B32, 0, x, 0, 16);
+
+      for (i = 8; i > 0; i -= 2) {
+        x[ 4] ^= R(x[ 0]+x[12], 7);  x[ 8] ^= R(x[ 4]+x[ 0], 9);
+        x[12] ^= R(x[ 8]+x[ 4],13);  x[ 0] ^= R(x[12]+x[ 8],18);
+        x[ 9] ^= R(x[ 5]+x[ 1], 7);  x[13] ^= R(x[ 9]+x[ 5], 9);
+        x[ 1] ^= R(x[13]+x[ 9],13);  x[ 5] ^= R(x[ 1]+x[13],18);
+        x[14] ^= R(x[10]+x[ 6], 7);  x[ 2] ^= R(x[14]+x[10], 9);
+        x[ 6] ^= R(x[ 2]+x[14],13);  x[10] ^= R(x[ 6]+x[ 2],18);
+        x[ 3] ^= R(x[15]+x[11], 7);  x[ 7] ^= R(x[ 3]+x[15], 9);
+        x[11] ^= R(x[ 7]+x[ 3],13);  x[15] ^= R(x[11]+x[ 7],18);
+        x[ 1] ^= R(x[ 0]+x[ 3], 7);  x[ 2] ^= R(x[ 1]+x[ 0], 9);
+        x[ 3] ^= R(x[ 2]+x[ 1],13);  x[ 0] ^= R(x[ 3]+x[ 2],18);
+        x[ 6] ^= R(x[ 5]+x[ 4], 7);  x[ 7] ^= R(x[ 6]+x[ 5], 9);
+        x[ 4] ^= R(x[ 7]+x[ 6],13);  x[ 5] ^= R(x[ 4]+x[ 7],18);
+        x[11] ^= R(x[10]+x[ 9], 7);  x[ 8] ^= R(x[11]+x[10], 9);
+        x[ 9] ^= R(x[ 8]+x[11],13);  x[10] ^= R(x[ 9]+x[ 8],18);
+        x[12] ^= R(x[15]+x[14], 7);  x[13] ^= R(x[12]+x[15], 9);
+        x[14] ^= R(x[13]+x[12],13);  x[15] ^= R(x[14]+x[13],18);
+      }
+
+      for (i = 0; i < 16; ++i) B32[i] = x[i] + B32[i];
+
+      for (i = 0; i < 16; i++) {
+        var bi = i * 4;
+        B[bi + 0] = (B32[i] >> 0  & 0xff);
+        B[bi + 1] = (B32[i] >> 8  & 0xff);
+        B[bi + 2] = (B32[i] >> 16 & 0xff);
+        B[bi + 3] = (B32[i] >> 24 & 0xff);
+      }
+    }
+
+    function blockxor (S, Si, D, Di, len) {
+      var i = len>>6;
+      while (i--) {
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+        D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+      }
+    }
+
+    function integerify (B, bi, r) {
+      var n;
+
+      bi += (2 * r - 1) * 64;
+
+      n  = (B[bi + 0] & 0xff) << 0;
+      n |= (B[bi + 1] & 0xff) << 8;
+      n |= (B[bi + 2] & 0xff) << 16;
+      n |= (B[bi + 3] & 0xff) << 24;
+
+      return n;
+    }
+
+    function arraycopy (src, srcPos, dest, destPos, length) {
+      while (length-- ){
+        dest[destPos++] = src[srcPos++];
+      }
+    }
+
+    function arraycopy32 (src, srcPos, dest, destPos, length) {
+      var i = length>>5;
+      while(i--) {
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+        dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+      }
+    }
+  } // scryptCore
+}
+
 module.exports = {
   encryptWallet: encryptWallet,
   decryptWallet: decryptWallet,
@@ -318,6 +540,7 @@ module.exports = {
   pbkdf2: pbkdf2,
   hashNTimes: hashNTimes,
   sha256: sha256,
+  scrypt: scrypt,
   AES: AES,
   algo: ALGO,
   pad: {

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -82,6 +82,19 @@ function recoverGuid (user_email, captcha) {
     .then(handleResponse).catch(handleError('Could not send recovery email'));
 }
 
+function checkWalletChecksum (payload_checksum, success, error) {
+  assert(payload_checksum, 'Payload checksum missing');
+  var data = {method : 'wallet.aes.json', format : 'json', checksum : payload_checksum};
+
+  API.securePostCallbacks('wallet', data, function (obj) {
+    if (!obj.payload || obj.payload == 'Not modified') {
+      if (success) success();
+    } else if (error) error();
+  }, function () {
+    if (error) error();
+  });
+}
+
 /**
  * Trigger the 2FA reset process
  * @param {string} user_guid User GUID.
@@ -169,6 +182,7 @@ function insertWallet (guid, sharedKey, password, extra, decryptWalletProgress) 
 }
 
 module.exports = {
+  checkWalletChecksum: checkWalletChecksum,
   insertWallet: insertWallet,
   generateUUIDs: generateUUIDs,
   resendTwoFactorSms: resendTwoFactorSms,

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -3,15 +3,12 @@
 var MyWallet = module.exports = {};
 
 var assert = require('assert');
-var Bitcoin = require('bitcoinjs-lib');
-var BigInteger = require('bigi');
 var Buffer = require('buffer').Buffer;
-var Base58 = require('bs58');
-var BIP39 = require('bip39');
 
 var WalletStore = require('./wallet-store');
 var WalletCrypto = require('./wallet-crypto');
 var WalletSignup = require('./wallet-signup');
+var WalletNetwork = require('./wallet-network');
 var API = require('./api');
 var Wallet = require('./blockchain-wallet');
 var Helpers = require('./helpers');
@@ -83,19 +80,6 @@ function didDecryptWallet (success) {
   MyWallet.getWallet();
   WalletStore.resetLogoutTimeout();
   success();
-}
-
-// used once
-function checkWalletChecksum (payload_checksum, success, error) {
-  var data = {method : 'wallet.aes.json', format : 'json', checksum : payload_checksum};
-
-  API.securePostCallbacks('wallet', data, function (obj) {
-    if (!obj.payload || obj.payload == 'Not modified') {
-      if (success) success();
-    } else if (error) error();
-  }, function (e) {
-    if (error) error();
-  });
 }
 
 //Fetch a new wallet from the server
@@ -489,7 +473,7 @@ function syncWallet (successcallback, errorcallback) {
             'wallet'
           , data
           , function (data) {
-              checkWalletChecksum(
+              WalletNetwork.checkWalletChecksum(
                   new_checksum
                 , function () {
                     WalletStore.setIsSynchronizedWithServer(true);

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -189,7 +189,7 @@ MyWallet.makePairingCode = function (success, error) {
 MyWallet.login = function ( user_guid
                           , shared_key
                           , inputedPassword
-                          , twoFACode
+                          , twoFA
                           , success
                           , needs_two_factor_code
                           , wrong_two_factor_code
@@ -201,7 +201,12 @@ MyWallet.login = function ( user_guid
 
   assert(success, 'Success callback required');
   assert(other_error, 'Error callback required');
-  assert(twoFACode !== undefined, '2FA code must be null or set');
+  assert(twoFA !== undefined, '2FA code must be null or set');
+  assert(
+    twoFA === null ||
+    Helpers.isString(twoFA) ||
+    (Helpers.isPositiveInteger(twoFA.type) && Helpers.isString(twoFA.code))
+  );
 
   var clientTime = (new Date()).getTime();
   var data = { format : 'json', resend_code : null, ct : clientTime, api_code : API.API_CODE };
@@ -256,18 +261,33 @@ MyWallet.login = function ( user_guid
     API.request('GET', 'wallet/' + guid, data, true, false).then(success).catch(error);
   };
 
-  var tryToFetchWalletWith2FA = function (guid, two_factor_auth_key, successCallback) {
+  var tryToFetchWalletWith2FA = function (guid, two_factor_auth, successCallback) {
 
-    if (two_factor_auth_key == null) {
+    if(Helpers.isString(two_factor_auth)) {
+      two_factor_auth = {
+        type: null,
+        code: two_factor_auth
+      };
+    }
+
+    if (two_factor_auth.code == null) {
       other_error('Two Factor Authentication code this null');
       return;
     }
-    if (two_factor_auth_key.length == 0 || two_factor_auth_key.length > 255) {
+    if (two_factor_auth.code.length == 0 || two_factor_auth.code.length > 255) {
      other_error('You must enter a Two Factor Authentication code');
      return;
     }
 
-    two_factor_auth_key = two_factor_auth_key.toUpperCase();
+    var two_factor_auth_key = two_factor_auth.code;
+
+    switch(two_factor_auth.type) {
+      case 2: // email
+      case 4: // sms
+      case 5: // Google Auth
+        two_factor_auth_key = two_factor_auth_key.toUpperCase();
+      break;
+    }
 
     var success = function (data) {
      if (data == null || data.length == 0) {
@@ -297,7 +317,7 @@ MyWallet.login = function ( user_guid
     MyWallet.initializeWallet(inputedPassword, success, other_error, decrypt_success, build_hd_success);
   }
 
-  if(twoFACode == null) {
+  if(twoFA == null) {
     tryToFetchWalletJSON(user_guid, didFetchWalletJSON)
   } else {
     // If 2FA is enabled and we already fetched the wallet before, don't fetch
@@ -305,7 +325,7 @@ MyWallet.login = function ( user_guid
     if(user_guid === WalletStore.getGuid() && WalletStore.getEncryptedWalletData()) {
       MyWallet.initializeWallet(inputedPassword, success, other_error, decrypt_success, build_hd_success);
     } else {
-      tryToFetchWalletWith2FA(user_guid, twoFACode, didFetchWalletJSON)
+      tryToFetchWalletWith2FA(user_guid, twoFA, didFetchWalletJSON)
     }
   }
 };

--- a/tests/address_spec.js.coffee
+++ b/tests/address_spec.js.coffee
@@ -23,13 +23,13 @@ ImportExport =
   shouldReject: true
   shouldFail: true
 
-  parseBIP38toECKey: (b58, pass, succ, wrong, error) ->
+  parseBIP38toECKey: (b58, pass) ->
     if ImportExport.shouldResolve
-      succ('5KUwyCzLyDjAvNGN4qmasFqnSimHzEYVTuHLNyME63JKfVU4wiU')
-    else if ImportExport.shouldReject
-      wrong()
+      Promise.resolve({ key: '5KUwyCzLyDjAvNGN4qmasFqnSimHzEYVTuHLNyME63JKfVU4wiU'})
     else if ImportExport.shouldFail
-      error()
+      Promise.reject('Invalid Private Key')
+    else if ImportExport.shouldReject
+      Promise.reject('wrong password')
 
 stubs = {
   './wallet': MyWallet,
@@ -315,12 +315,12 @@ describe "Address", ->
       it "should not import BIP-38 format with a bad password", (done) ->
         ImportExport.shouldReject = true
         promise = Address.fromString("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg", null, "pass", done)
-        expect(promise).toBeRejectedWith('wrongBipPass', done)
+        expect(promise).toBeRejectedWith('wrong password', done)
 
       it "should not import BIP-38 format if the decryption fails", (done) ->
         ImportExport.shouldFail = true
         promise = Address.fromString("6PRVWUbkzzsbcVac2qwfssoUJAN1Xhrg6bNk8J7Nzm5H7kxEbn2Nh2ZoGg", null, "pass", done)
-        expect(promise).toBeRejectedWith('importError', done)
+        expect(promise).toBeRejectedWith('Invalid Private Key', done)
 
       it "should import BIP-38 format with a correct password", (done) ->
         ImportExport.shouldResolve = true

--- a/tests/blockchain_socket.js.coffee
+++ b/tests/blockchain_socket.js.coffee
@@ -72,3 +72,78 @@ describe "Websocket", ->
         it "should do nothing", ->
           # ws.socket is not defined, so nothing to spy on
           expect(() -> ws.send(message)).not.toThrow()
+
+    describe "msgWalletSub()", ->
+      it "should subscribe to a guid", ->
+        res = ws.msgWalletSub("1234")
+        expected = JSON.stringify({op: "wallet_sub", guid: "1234"})
+        expect(res).toEqual(expected)
+
+      it "should return an empty string if guid is missing", ->
+        res = ws.msgWalletSub(null)
+        expected = ""
+        expect(res).toEqual(expected)
+
+    describe "msgBlockSub()", ->
+      it "should subscribe to new blocks", ->
+        res = ws.msgBlockSub()
+        expected = JSON.stringify({op: "blocks_sub"})
+        expect(res).toEqual(expected)
+
+    describe "msgAddrSub()", ->
+      it "should return an empty string if addresses are missing", ->
+        res = ws.msgAddrSub(null)
+        expected = ""
+        expect(res).toEqual(expected)
+
+      it "should subscribe to one adddress", ->
+        res = ws.msgAddrSub("1abc")
+        expected = JSON.stringify({op: "addr_sub", addr: "1abc"})
+        expect(res).toEqual(expected)
+
+      it "should subscribe to array of adddresses", ->
+        res = ws.msgAddrSub(["1abc", "1def"])
+        expected = JSON.stringify({op: "addr_sub", addr: "1abc"}) +
+                   JSON.stringify({op: "addr_sub", addr: "1def"})
+        expect(res).toEqual(expected)
+
+    describe "msgXPUBSub()", ->
+      it "should return an empty string if xpub is missing", ->
+        res = ws.msgXPUBSub(null)
+        expected = ""
+        expect(res).toEqual(expected)
+
+      it "should return an empty string if xpub is []", ->
+        res = ws.msgXPUBSub([])
+        expected = ""
+        expect(res).toEqual(expected)
+
+      it "should subscribe to one xpub", ->
+        res = ws.msgXPUBSub("1abc")
+        expected = JSON.stringify({op: "xpub_sub", xpub: "1abc"})
+        expect(res).toEqual(expected)
+
+      it "should subscribe to array of adddresses", ->
+        res = ws.msgXPUBSub(["1abc", "1def"])
+        expected = JSON.stringify({op: "xpub_sub", xpub: "1abc"}) +
+                   JSON.stringify({op: "xpub_sub", xpub: "1def"})
+        expect(res).toEqual(expected)
+
+    describe "msgPing()", ->
+      it "should ping", ->
+        res = ws.msgPing()
+        expected = JSON.stringify({op: "ping"})
+        expect(res).toEqual(expected)
+
+    describe "msgOnOpen()", ->
+      it "should subscribe to blocks, guid, addresses and xpubs", ->
+        guid = "1234"
+        addresses = ["123a", "1bcd"]
+        xpubs = "1eff"
+        res = ws.msgOnOpen(guid, addresses, xpubs)
+        expected = JSON.stringify({op: "blocks_sub"}) +
+                   JSON.stringify({op: "wallet_sub", guid: "1234"}) +
+                   JSON.stringify({op: "addr_sub", addr: "123a"}) +
+                   JSON.stringify({op: "addr_sub", addr: "1bcd"}) +
+                   JSON.stringify({op: "xpub_sub", xpub: "1eff"})
+        expect(res).toEqual(expected)

--- a/tests/payment_spec.js.coffee
+++ b/tests/payment_spec.js.coffee
@@ -6,6 +6,7 @@ MyWallet =
   wallet:
     fee_per_kb: 10000
     isUpgradedToHD: true
+    key: () -> { priv: null, address: '16SPAGz8vLpP3jNTcP7T2io1YccMbjhkee' }
     spendableActiveAddresses: [
       '16SPAGz8vLpP3jNTcP7T2io1YccMbjhkee',
       '1FBHaa3JNjTbhvzMBdv2ymaahmgSSJ4Mis',

--- a/tests/wallet_crypto_spec.js.coffee
+++ b/tests/wallet_crypto_spec.js.coffee
@@ -168,3 +168,40 @@ describe 'WalletCrypto', ->
 
     it 'should not modify the operation is unknown', ->
       expect(WalletCrypto.cipherFunction('password', 'key', 1000, 'nop')('toto')).toEqual('toto')
+
+  describe 'scrypt', ->
+    it 'should not an invalid CPU cost parameter', ->
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1023, 1, 1, 64, () -> )).toThrowError('N must be > 0 and a power of 2')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', -1, 1, 1, 64, () -> )).toThrowError('N must be > 0 and a power of 2')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', [1024], 1, 1, 64, () -> )).toThrowError('N must be > 0 and a power of 2')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', {'n': 1024}, 1, 1, 64, () -> )).toThrowError('N must be > 0 and a power of 2')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2048.234, 1, 1, 64, () -> )).toThrowError('N must be > 0 and a power of 2')
+
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2147483648 / 64, 1, 1, 64, () -> )).toThrowError('Parameter N is too large')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2147483648 / 128, 2, 1, 64, () -> )).toThrowError('Parameter N is too large')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2147483648 / 1024, 10, 1, 64, () -> )).toThrowError('Parameter N is too large')
+
+    it 'should not an invalid r parameter', ->
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, -1, 1, 64, () -> )).toThrowError('Parameter r must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 0, 1, 64, () -> )).toThrowError('Parameter r must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1.234234, 1, 64, () -> )).toThrowError('Parameter r must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, [1], 1, 64, () -> )).toThrowError('Parameter r must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, {'n': 1}, 1, 64, () -> )).toThrowError('Parameter r must be a positive integer')
+
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2, 2147483648 / 1024, 10, 64, () -> )).toThrowError('Parameter r is too large')
+
+
+    it 'should not an invalid p parameter', ->
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1, -1, 64, () -> )).toThrowError('Parameter p must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1, 0, 64, () -> )).toThrowError('Parameter p must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1, 1.2342, 64, () -> )).toThrowError('Parameter p must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1, [1], 64, () -> )).toThrowError('Parameter p must be a positive integer')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1, {'n': 1}, 64, () -> )).toThrowError('Parameter p must be a positive integer')
+
+    it 'should accept valid dkLen parameter', ->
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2, 1, 1, -64, () -> )).toThrowError('Parameter dkLen must be ≤ (2^32− 1) * hLen')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 128, 1, 1, 0, () -> )).toThrowError('Parameter dkLen must be ≤ (2^32− 1) * hLen')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 512, 1, 1, 64.2342, () -> )).toThrowError('Parameter dkLen must be ≤ (2^32− 1) * hLen')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 1024, 1, 1, [64], () -> )).toThrowError('Parameter dkLen must be ≤ (2^32− 1) * hLen')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2048, 1, 1, {'n': 64}, () -> )).toThrowError('Parameter dkLen must be ≤ (2^32− 1) * hLen')
+      expect(() -> WalletCrypto.scrypt('password', 'salt', 2048, 1, 1, 2147483647 * 32 + 1, () -> )).toThrowError('Parameter dkLen must be ≤ (2^32− 1) * hLen')


### PR DESCRIPTION
- Moved scrypt crypto function to wallet-crypto
- Removed callbacks from parseBIP38toECKey and made it into a promise
- Implemented tighter checks on scrypt parameters

parseBIP38toECKey is now the only function remaining in import-export. I didn't kill the file completely this time as moving the function to wallet-crypto would require BIP-38 tests to be modified.

Tested it using the frontend and a paperwallet from bitaddress.