### PR TITLE
Spend watch only

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,7 +7,6 @@ var Buffer = require('buffer').Buffer;
 var Base58 = require('bs58');
 var BIP39 = require('bip39');
 var shared = require('./shared');
-var Address = require('./address');
 var ImportExport = require('./import-export');
 
 var Helpers = {};
@@ -395,7 +394,7 @@ Helpers.privateKeyCorrespondsToAddress = function (address, priv, bipPass) {
   }
   var predicate = function(key){
     var a = key.pub.getAddress().toString();
-    return a === address;
+    return a === address? Base58.encode(key.d.toBuffer(32)) : null;
   }
   return new Promise(asyncParse).then(predicate);
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,6 +7,8 @@ var Buffer = require('buffer').Buffer;
 var Base58 = require('bs58');
 var BIP39 = require('bip39');
 var shared = require('./shared');
+var Address = require('./address');
+var ImportExport = require('./import-export');
 
 var Helpers = {};
 Math.log2 = function (x) { return Math.log(x) / Math.LN2;};
@@ -369,6 +371,33 @@ Helpers.isValidPrivateKey = function (candidate) {
   } catch (e) {
     return false;
   }
+};
+
+Helpers.privateKeyCorrespondsToAddress = function (address, priv, bipPass) {
+  var asyncParse = function (resolve, reject) {
+    var format    = Helpers.detectPrivateKeyFormat(priv)
+      , okFormats = ['base58', 'base64', 'hex', 'mini', 'sipa', 'compsipa'];
+    if (format === 'bip38') {
+      if (bipPass == undefined || bipPass === '') {
+        return reject('needsBip38');
+      }
+      ImportExport.parseBIP38toECKey(priv, bipPass,
+        function (key) { resolve(key);},
+        function ()    { reject('wrongBipPass'); },
+        function ()    { reject('importError');}
+      );
+    }
+    else if (okFormats.indexOf(format) > -1) {
+      var k = Helpers.privateKeyStringToKey(priv, format);
+      return resolve(k);
+    }
+    else { reject('unknown key format'); }
+  }
+  var predicate = function(key){
+    var a = key.pub.getAddress().toString();
+    return a === address;
+  }
+  return new Promise(asyncParse).then(predicate);
 };
 
 function parseValueBitcoin (valueString) {

--- a/tests/payment_spec.js.coffee
+++ b/tests/payment_spec.js.coffee
@@ -6,6 +6,7 @@ MyWallet =
   wallet:
     fee_per_kb: 10000
     isUpgradedToHD: true
+    key: () -> { priv: null, address: '16SPAGz8vLpP3jNTcP7T2io1YccMbjhkee' }
     spendableActiveAddresses: [
       '16SPAGz8vLpP3jNTcP7T2io1YccMbjhkee',
       '1FBHaa3JNjTbhvzMBdv2ymaahmgSSJ4Mis',


### PR DESCRIPTION
Currently this works on iOS in the following steps:

1. The frontend has to call Helpers.privateKeyCorrespondsToAddress(address, priv, bipPass) to check whether it's the correct key or not before setting
2. If it's the correct private key, it is set as the Payment.from.
3. Build and send payment as usual.

Refactoring this to set the public key as Payment.from and include an 'addPrivateKeyToAddress' function (generally moving more of the logic into My-Wallet-V3) has been discussed for the future.