### PR TITLE
Transaction: localizable error messages

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -6,6 +6,10 @@ var randomBytes = require('randombytes');
 var Helpers     = require('./helpers');
 var Buffer      = require('buffer').Buffer;
 
+// Error messages that can be seen by the user should take the form of:
+// {error: "NOT_GOOD", some_param: 1}
+// Error messages that should only appear during development can be any string.
+
 var Transaction = function (unspentOutputs, toAddresses, amounts, fee, feePerKb, changeAddress, listener) {
 
   if (!Array.isArray(toAddresses) && toAddresses != null) {toAddresses = [toAddresses];}
@@ -26,8 +30,8 @@ var Transaction = function (unspentOutputs, toAddresses, amounts, fee, feePerKb,
   feePerKb = Helpers.isNumber(feePerKb) ? feePerKb : 10000;
 
   assert(toAddresses.length == amounts.length, 'The number of destiny addresses and destiny amounts should be the same.');
-  assert(this.amount > BITCOIN_DUST, this.amount + ' must be above dust threshold (' + BITCOIN_DUST + ' Satoshis)');
-  assert(unspentOutputs && unspentOutputs.length > 0, 'Missing coins to spend');
+  assert(this.amount > BITCOIN_DUST, {error: 'BELOW_DUST_THRESHOLD', amount: this.amount, threshold: BITCOIN_DUST});
+  assert(unspentOutputs && unspentOutputs.length > 0, {error: 'NO_UNSPENT_OUTPUTS'});
 
   var transaction = new Bitcoin.Transaction();
   // add all outputs
@@ -52,9 +56,9 @@ var Transaction = function (unspentOutputs, toAddresses, amounts, fee, feePerKb,
     // Generate address from output script and add to private list so we can check if the private keys match the inputs later
 
     var script = Bitcoin.Script.fromHex(output.script);
-    assert.notEqual(Bitcoin.scripts.classifyOutput(script), 'nonstandard', 'Strange Script');
+    assert.notEqual(Bitcoin.scripts.classifyOutput(script), 'nonstandard', {error: 'STRANGE_SCRIPT'});
     var address = Bitcoin.Address.fromOutputScript(script).toString();
-    assert(address, 'Unable to decode output address from transaction hash ' + output.tx_hash);
+    assert(address, {error: 'CANNOT_DECODE_OUTPUT_ADDRESS', tx_hash: output.tx_hash});
     this.addressesOfInputs.push(address);
 
     // Add to list of needed private keys

--- a/tests/transaction_spend_spec.js.coffee
+++ b/tests/transaction_spend_spec.js.coffee
@@ -105,7 +105,7 @@ describe "Transaction", ->
         new Transaction(null, data.to, data.amount, data.fee, data.feePerKb, data.from, null)
       catch e
         expect(e.name).toBe('AssertionError')
-        expect(e.message).toBe('Missing coins to spend')
+        expect(e.message.error).toBe('NO_UNSPENT_OUTPUTS')
 
     it "should fail without amount lower than dust threshold", ->
 
@@ -115,7 +115,7 @@ describe "Transaction", ->
         new Transaction(data.unspentMock, data.to, data.amount, data.fee, data.feePerKb, data.from, null)
       catch e
         expect(e.name).toBe('AssertionError')
-        expect(e.message).toContain('dust threshold')
+        expect(e.message.error).toBe('BELOW_DUST_THRESHOLD')
 
     it "should initialize with good data", ->
 


### PR DESCRIPTION
This allows the frontend to translate error messages.

It's really convenient for the frontend: just takes the error property and then passes the whole dictionary to $translate.

`{error: 'BELOW_DUST_THRESHOLD', amount: this.amount, threshold: BITCOIN_DUST}`

Will work with:
` "BELOW_DUST_THRESHOLD" : "{{ amount  }} must be above dust threshold ({{ threshold }} Satoshis)"`

We should bump the minor version.
