### PR TITLE
fix(Transaction): add transaction amount to iOS factory

### DIFF
--- a/src/wallet-transaction.js
+++ b/src/wallet-transaction.js
@@ -248,6 +248,7 @@ Tx.IOSfactory = function (tx){
   return {
     time          : tx.time,
     result        : tx.result,
+    amount        : tx.amount,
     confirmations : tx.confirmations,
     myHash        : tx.hash,
     txType        : tx.txType,


### PR DESCRIPTION
Let me know if I'm missing anything. Transfers now display the amount transferred, and sends and receives all maintain the same values as before.