### PR TITLE
Make sure stretchPassword is using sha1

### DIFF
--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -276,6 +276,7 @@ function stretchPassword (password, salt, iterations, keylen) {
   assert(salt, 'salt missing');
   assert(password, 'password missing');
   assert(iterations, 'iterations missing');
+  assert(typeof(sjcl.hash.sha1) === 'function', 'missing sha1, make sure sjcl is configured correctly');
 
   var hmacSHA1 = function (key) {
     var hasher = new sjcl.misc.hmac(key, sjcl.hash.sha1);


### PR DESCRIPTION
If sjcl isn't configured correctly, `sjcl.hash.sha1` will be `undefined`. If that happens, `sjcl.misc.hmac` will default to using sha256.