### PR TITLE
Add getter for dust threshold for transfer all funds

### DIFF
--- a/src/payment.js
+++ b/src/payment.js
@@ -75,7 +75,8 @@ function Payment (payment) {
     sweepFees: [0,0,0,0,0,0], // sweep absolute fee per each fee per kb (1,2,3,4,5,6)
     maxSpendableAmounts: [0,0,0,0,0,0],  // max amount per each fee-per-kb
     confEstimation: "unknown",
-    txSize: 0 // transaciton size
+    txSize: 0, // transaciton size
+    dustThreshold: 0
   };
 
   var p = payment ? payment : initialState;
@@ -395,6 +396,7 @@ Payment.prebuild = function (absoluteFee) {
     payment.sweepAmount = max.amount;
     payment.sweepFee    = max.fee;
     payment.balance     = Transaction.sumOfCoins(payment.coins);
+    payment.dustThreshold = dust;
 
     // compute max spendable limits per each fee-per-kb
     var maxSpendablesPerFeePerKb = function(e){


### PR DESCRIPTION
Transfer all funds on iOS selects addresses that meet the following requirements:
- Unarchived
- Non watch-only
- UseAll() returns a sweepAmount > dust

Currently the only way to read the dust value is to obtain it from the error message, which is unnecessary work for the frontend for this purpose.