### PR TITLE
Moved crypt function to WalletCrypto

### DIFF
--- a/src/import-export.js
+++ b/src/import-export.js
@@ -5,6 +5,7 @@ var BigInteger = require('bigi');
 var Base58 = require('bs58');
 var Unorm = require('unorm');
 var WalletCrypto = require('./wallet-crypto');
+var Buffer = require('buffer').Buffer;
 
 var hash256 = Bitcoin.crypto.hash256;
 
@@ -83,7 +84,7 @@ var ImportExport = new function () {
     if (!isECMult) {
       var addresshash = Buffer(hex.slice(3, 7));
 
-      ImportExport.Crypto_scrypt(passphrase, addresshash, 16384, 8, 8, 64, function (derivedBytes) {
+      WalletCrypto.scrypt(passphrase, addresshash, 16384, 8, 8, 64, function (derivedBytes) {
         var k = derivedBytes.slice(32, 32 + 32);
 
         var decryptedBytes = WalletCrypto.AES.decrypt(Buffer(hex.slice(7, 7 + 32)), k, null, AES_opts);
@@ -97,7 +98,7 @@ var ImportExport = new function () {
       var ownerentropy = hex.slice(7, 7 + 8);
       var ownersalt = Buffer(!hasLotSeq ? ownerentropy : ownerentropy.slice(0, 4));
 
-      ImportExport.Crypto_scrypt(passphrase, ownersalt, 16384, 8, 8, 32, function (prefactorA) {
+      WalletCrypto.scrypt(passphrase, ownersalt, 16384, 8, 8, 32, function (prefactorA) {
         var passfactor;
 
         if (!hasLotSeq) {
@@ -115,7 +116,7 @@ var ImportExport = new function () {
 
         var addresshashplusownerentropy = Buffer(hex.slice(3, 3 + 12));
 
-        ImportExport.Crypto_scrypt(passpoint, addresshashplusownerentropy, 1024, 1, 1, 64, function (derived) {
+        WalletCrypto.scrypt(passpoint, addresshashplusownerentropy, 1024, 1, 1, 64, function (derived) {
           var k = derived.slice(32);
 
           var unencryptedpart2Bytes = WalletCrypto.AES.decrypt(encryptedpart2, k, null, AES_opts);
@@ -141,242 +142,7 @@ var ImportExport = new function () {
         });
       });
     }
-  };
-
-  var MAX_VALUE = 2147483647;
-
-  this.Crypto_scrypt = function (passwd, salt, N, r, p, dkLen, callback) {
-    if (N == 0 || (N & (N - 1)) != 0) throw Error('N must be > 0 and a power of 2');
-
-    if (N > MAX_VALUE / 128 / r) throw Error('Parameter N is too large');
-    if (r > MAX_VALUE / 128 / p) throw Error('Parameter r is too large');
-
-    if (!Buffer.isBuffer(passwd)) {
-      passwd = new Buffer(passwd, 'utf8');
-    }
-
-    if (!Buffer.isBuffer(salt)) {
-      salt = new Buffer(salt, 'utf8');
-    }
-
-    var B = WalletCrypto.pbkdf2(passwd, salt, 1, (p * 128 * r), WalletCrypto.algo.SHA256);
-
-    // Called in Firefox and IE which don't support Blob web workers with CSP enabled.
-    window.setTimeout(function () {
-      scryptCore();
-      var ret = WalletCrypto.pbkdf2(passwd, B, 1, dkLen, WalletCrypto.algo.SHA256);
-
-      callback(ret);
-    }, 0);
-    // }
-
-    // using this function to enclose everything needed to create a worker (but also invokable directly for synchronous use)
-    function scryptCore () {
-      var XY = [];
-      var V = [];
-
-      if (typeof B === 'undefined') {
-        onmessage = function (event) {
-          var data = event.data;
-          var N = data[0];
-          var r = data[1];
-          var B = data[3];
-          var i = data[4];
-
-          var Bslice = [];
-          arraycopy32(B, i * 128 * r, Bslice, 0, 128 * r);
-          smix(Bslice, 0, r, N, V, XY);
-
-          postMessage([i, Bslice]);
-        };
-      } else {
-        for (var i = 0; i < p; i++) {
-          smix(B, i * 128 * r, r, N, V, XY);
-        }
-      }
-
-      function smix (B, Bi, r, N, V, XY) {
-        var Xi = 0;
-        var Yi = 128 * r;
-        var i;
-
-        arraycopy32(B, Bi, XY, Xi, Yi);
-
-        for (i = 0; i < N; i++) {
-          arraycopy32(XY, Xi, V, i * Yi, Yi);
-          blockmix_salsa8(XY, Xi, Yi, r);
-        }
-
-        for (i = 0; i < N; i++) {
-          var j = integerify(XY, Xi, r) & (N - 1);
-          blockxor(V, j * Yi, XY, Xi, Yi);
-          blockmix_salsa8(XY, Xi, Yi, r);
-        }
-
-        arraycopy32(XY, Xi, B, Bi, Yi);
-      }
-
-      function blockmix_salsa8 (BY, Bi, Yi, r) {
-        var X = [];
-        var i;
-
-        arraycopy32(BY, Bi + (2 * r - 1) * 64, X, 0, 64);
-
-        for (i = 0; i < 2 * r; i++) {
-          blockxor(BY, i * 64, X, 0, 64);
-          salsa20_8(X);
-          arraycopy32(X, 0, BY, Yi + (i * 64), 64);
-        }
-
-        for (i = 0; i < r; i++) {
-          arraycopy32(BY, Yi + (i * 2) * 64, BY, Bi + (i * 64), 64);
-        }
-
-        for (i = 0; i < r; i++) {
-          arraycopy32(BY, Yi + (i * 2 + 1) * 64, BY, Bi + (i + r) * 64, 64);
-        }
-      }
-
-      function R (a, b) {
-        return (a << b) | (a >>> (32 - b));
-      }
-
-      function salsa20_8 (B) {
-        var B32 = new Array(32);
-        var x = new Array(32);
-        var i;
-
-        for (i = 0; i < 16; i++) {
-          B32[i] = (B[i * 4 + 0] & 0xff) << 0;
-          B32[i] |= (B[i * 4 + 1] & 0xff) << 8;
-          B32[i] |= (B[i * 4 + 2] & 0xff) << 16;
-          B32[i] |= (B[i * 4 + 3] & 0xff) << 24;
-        }
-
-        arraycopy(B32, 0, x, 0, 16);
-
-        for (i = 8; i > 0; i -= 2) {
-          /*eslint-disable */
-          x[ 4] ^= R(x[ 0]+x[12], 7);  x[ 8] ^= R(x[ 4]+x[ 0], 9);
-          x[12] ^= R(x[ 8]+x[ 4],13);  x[ 0] ^= R(x[12]+x[ 8],18);
-          x[ 9] ^= R(x[ 5]+x[ 1], 7);  x[13] ^= R(x[ 9]+x[ 5], 9);
-          x[ 1] ^= R(x[13]+x[ 9],13);  x[ 5] ^= R(x[ 1]+x[13],18);
-          x[14] ^= R(x[10]+x[ 6], 7);  x[ 2] ^= R(x[14]+x[10], 9);
-          x[ 6] ^= R(x[ 2]+x[14],13);  x[10] ^= R(x[ 6]+x[ 2],18);
-          x[ 3] ^= R(x[15]+x[11], 7);  x[ 7] ^= R(x[ 3]+x[15], 9);
-          x[11] ^= R(x[ 7]+x[ 3],13);  x[15] ^= R(x[11]+x[ 7],18);
-          x[ 1] ^= R(x[ 0]+x[ 3], 7);  x[ 2] ^= R(x[ 1]+x[ 0], 9);
-          x[ 3] ^= R(x[ 2]+x[ 1],13);  x[ 0] ^= R(x[ 3]+x[ 2],18);
-          x[ 6] ^= R(x[ 5]+x[ 4], 7);  x[ 7] ^= R(x[ 6]+x[ 5], 9);
-          x[ 4] ^= R(x[ 7]+x[ 6],13);  x[ 5] ^= R(x[ 4]+x[ 7],18);
-          x[11] ^= R(x[10]+x[ 9], 7);  x[ 8] ^= R(x[11]+x[10], 9);
-          x[ 9] ^= R(x[ 8]+x[11],13);  x[10] ^= R(x[ 9]+x[ 8],18);
-          x[12] ^= R(x[15]+x[14], 7);  x[13] ^= R(x[12]+x[15], 9);
-          x[14] ^= R(x[13]+x[12],13);  x[15] ^= R(x[14]+x[13],18);
-          /*eslint-enable */
-        }
-
-        for (i = 0; i < 16; ++i) B32[i] = x[i] + B32[i];
-
-        for (i = 0; i < 16; i++) {
-          var bi = i * 4;
-          B[bi + 0] = (B32[i] >> 0 & 0xff);
-          B[bi + 1] = (B32[i] >> 8 & 0xff);
-          B[bi + 2] = (B32[i] >> 16 & 0xff);
-          B[bi + 3] = (B32[i] >> 24 & 0xff);
-        }
-      }
-
-      function blockxor (S, Si, D, Di, len) {
-        var i = len >> 6;
-        while (i--) {
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-          D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
-        }
-      }
-
-      function integerify (B, bi, r) {
-        var n;
-
-        bi += (2 * r - 1) * 64;
-
-        n = (B[bi + 0] & 0xff) << 0;
-        n |= (B[bi + 1] & 0xff) << 8;
-        n |= (B[bi + 2] & 0xff) << 16;
-        n |= (B[bi + 3] & 0xff) << 24;
-
-        return n;
-      }
-
-      function arraycopy (src, srcPos, dest, destPos, length) {
-        while (length--) {
-          dest[destPos++] = src[srcPos++];
-        }
-      }
-
-      function arraycopy32 (src, srcPos, dest, destPos, length) {
-        var i = length >> 5;
-        while (i--) {
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-          dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
-        }
-      }
-    } // scryptCore
-  };
+  }
 };
 
 module.exports = ImportExport;

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -315,6 +315,215 @@ function sha256 (data) {
   return crypto.createHash('sha256').update(data).digest();
 }
 
+function smix (B, Bi, r, N, V, XY) {
+  var Xi = 0;
+  var Yi = 128 * r;
+  var i;
+
+  arraycopy32(B, Bi, XY, Xi, Yi);
+
+  for (i = 0; i < N; i++) {
+    arraycopy32(XY, Xi, V, i * Yi, Yi);
+    blockmix_salsa8(XY, Xi, Yi, r);
+  }
+
+  for (i = 0; i < N; i++) {
+    var j = integerify(XY, Xi, r) & (N - 1);
+    blockxor(V, j * Yi, XY, Xi, Yi);
+    blockmix_salsa8(XY, Xi, Yi, r);
+  }
+
+  arraycopy32(XY, Xi, B, Bi, Yi);
+}
+
+function blockmix_salsa8 (BY, Bi, Yi, r) {
+  var X = [];
+  var i;
+
+  arraycopy32(BY, Bi + (2 * r - 1) * 64, X, 0, 64);
+
+  for (i = 0; i < 2 * r; i++) {
+    blockxor(BY, i * 64, X, 0, 64);
+    salsa20_8(X);
+    arraycopy32(X, 0, BY, Yi + (i * 64), 64);
+  }
+
+  for (i = 0; i < r; i++) {
+    arraycopy32(BY, Yi + (i * 2) * 64, BY, Bi + (i * 64), 64);
+  }
+
+  for (i = 0; i < r; i++) {
+    arraycopy32(BY, Yi + (i * 2 + 1) * 64, BY, Bi + (i + r) * 64, 64);
+  }
+}
+
+function R (a, b) {
+  return (a << b) | (a >>> (32 - b));
+}
+
+function salsa20_8 (B) {
+  var B32 = new Array(32);
+  var x = new Array(32);
+  var i;
+
+  for (i = 0; i < 16; i++) {
+    B32[i] = (B[i * 4 + 0] & 0xff) << 0;
+    B32[i] |= (B[i * 4 + 1] & 0xff) << 8;
+    B32[i] |= (B[i * 4 + 2] & 0xff) << 16;
+    B32[i] |= (B[i * 4 + 3] & 0xff) << 24;
+  }
+
+  arraycopy(B32, 0, x, 0, 16);
+
+  for (i = 8; i > 0; i -= 2) {
+    /*eslint-disable */
+    x[ 4] ^= R(x[ 0]+x[12], 7);  x[ 8] ^= R(x[ 4]+x[ 0], 9);
+    x[12] ^= R(x[ 8]+x[ 4],13);  x[ 0] ^= R(x[12]+x[ 8],18);
+    x[ 9] ^= R(x[ 5]+x[ 1], 7);  x[13] ^= R(x[ 9]+x[ 5], 9);
+    x[ 1] ^= R(x[13]+x[ 9],13);  x[ 5] ^= R(x[ 1]+x[13],18);
+    x[14] ^= R(x[10]+x[ 6], 7);  x[ 2] ^= R(x[14]+x[10], 9);
+    x[ 6] ^= R(x[ 2]+x[14],13);  x[10] ^= R(x[ 6]+x[ 2],18);
+    x[ 3] ^= R(x[15]+x[11], 7);  x[ 7] ^= R(x[ 3]+x[15], 9);
+    x[11] ^= R(x[ 7]+x[ 3],13);  x[15] ^= R(x[11]+x[ 7],18);
+    x[ 1] ^= R(x[ 0]+x[ 3], 7);  x[ 2] ^= R(x[ 1]+x[ 0], 9);
+    x[ 3] ^= R(x[ 2]+x[ 1],13);  x[ 0] ^= R(x[ 3]+x[ 2],18);
+    x[ 6] ^= R(x[ 5]+x[ 4], 7);  x[ 7] ^= R(x[ 6]+x[ 5], 9);
+    x[ 4] ^= R(x[ 7]+x[ 6],13);  x[ 5] ^= R(x[ 4]+x[ 7],18);
+    x[11] ^= R(x[10]+x[ 9], 7);  x[ 8] ^= R(x[11]+x[10], 9);
+    x[ 9] ^= R(x[ 8]+x[11],13);  x[10] ^= R(x[ 9]+x[ 8],18);
+    x[12] ^= R(x[15]+x[14], 7);  x[13] ^= R(x[12]+x[15], 9);
+    x[14] ^= R(x[13]+x[12],13);  x[15] ^= R(x[14]+x[13],18);
+    /*eslint-enable */
+  }
+
+  for (i = 0; i < 16; ++i) B32[i] = x[i] + B32[i];
+
+  for (i = 0; i < 16; i++) {
+    var bi = i * 4;
+    B[bi + 0] = (B32[i] >> 0 & 0xff);
+    B[bi + 1] = (B32[i] >> 8 & 0xff);
+    B[bi + 2] = (B32[i] >> 16 & 0xff);
+    B[bi + 3] = (B32[i] >> 24 & 0xff);
+  }
+}
+
+function blockxor (S, Si, D, Di, len) {
+  var i = len >> 6;
+  while (i--) {
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+    D[Di++] ^= S[Si++]; D[Di++] ^= S[Si++];
+  }
+}
+
+function integerify (B, bi, r) {
+  var n;
+
+  bi += (2 * r - 1) * 64;
+
+  n = (B[bi + 0] & 0xff) << 0;
+  n |= (B[bi + 1] & 0xff) << 8;
+  n |= (B[bi + 2] & 0xff) << 16;
+  n |= (B[bi + 3] & 0xff) << 24;
+
+  return n;
+}
+
+function arraycopy (src, srcPos, dest, destPos, length) {
+  while (length--) {
+    dest[destPos++] = src[srcPos++];
+  }
+}
+
+function arraycopy32 (src, srcPos, dest, destPos, length) {
+  var i = length >> 5;
+  while (i--) {
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+    dest[destPos++] = src[srcPos++]; dest[destPos++] = src[srcPos++];
+  }
+}
+
+function scrypt (passwd, salt, N, r, p, dkLen, callback) {
+  if (N == 0 || (N & (N - 1)) != 0) throw Error('N must be > 0 and a power of 2');
+
+  var MAX_VALUE = 2147483647;
+  if (N > MAX_VALUE / 128 / r) throw Error('Parameter N is too large');
+  if (r > MAX_VALUE / 128 / p) throw Error('Parameter r is too large');
+
+  if (!Buffer.isBuffer(passwd)) {
+    passwd = new Buffer(passwd, 'utf8');
+  }
+
+  if (!Buffer.isBuffer(salt)) {
+    salt = new Buffer(salt, 'utf8');
+  }
+
+  var B = pbkdf2(passwd, salt, 1, (p * 128 * r), ALGO.SHA256);
+
+  var XY = [];
+  var V = [];
+
+  for (var i = 0; i < p; i++) {
+    smix(B, i * 128 * r, r, N, V, XY);
+  }
+
+  callback(pbkdf2(passwd, B, 1, dkLen, ALGO.SHA256));
+
+}
+
 module.exports = {
   encryptWallet: encryptWallet,
   decryptWallet: decryptWallet,
@@ -329,6 +538,7 @@ module.exports = {
   pbkdf2: pbkdf2,
   hashNTimes: hashNTimes,
   sha256: sha256,
+  scrypt: scrypt,
   AES: AES,
   algo: ALGO,
   pad: {

--- a/tests/bip38_spec.js.coffee
+++ b/tests/bip38_spec.js.coffee
@@ -3,91 +3,9 @@ ECPair = Bitcoin.ECPair
 BigInteger = require('bigi')
 
 ImportExport = require('../src/import-export')
+WalletCrypto = require('../src/wallet-crypto')
 
-describe "Crypto_scrypt", ->
 
-  observer =
-    callback: (hash) ->
-
-  beforeEach ->
-    # overrride as a temporary solution
-    window.setTimeout = (myFunction) -> myFunction()
-
-  # Crypto_scrypt test vectors can be found at the end of this document:
-  ## http://www.tarsnap.com/scrypt/scrypt.pdf
-
-  it "Official test vector 1 should work", ->
-    spyOn(observer, "callback")
-    expected = "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442\
-                fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906"
-    ImportExport.Crypto_scrypt "", "" , 16, 1, 1, 64, observer.callback
-    expect(observer.callback).toHaveBeenCalled()
-    computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-    expect(expected).toEqual(computed)
-
-  # Not using official test vectors 2-4, because they are too slow. Using
-  # Haskell generated test vectors below instead.
-
-  # Disabled because it is too slow
-  # it "Official test vector 2 should work", ->
-  #   spyOn(observer, "callback")
-  #   expected = "fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731\
-  #               622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640"
-  #   ImportExport.Crypto_scrypt "password", "NaCl" , 1024, 8, 16, 64, observer.callback
-  #   expect(observer.callback).toHaveBeenCalled()
-  #   computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-  #   expect(expected).toEqual(computed)
-
-  # Disabled because it is too slow
-  # it "Official test vector 3 should work", ->
-  #   spyOn(observer, "callback")
-  #   expected = "7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2\
-  #               d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887"
-  #   ImportExport.Crypto_scrypt "pleaseletmein", "SodiumChloride", 16384, 8, 1, 64, observer.callback
-  #   expect(observer.callback).toHaveBeenCalled()
-  #   computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-  #   expect(expected).toEqual(computed)
-
-  # Disabled because it is too slow and PhantomJS runs out of memory
-  # it "Official test vector 4 should work", ->
-  #   spyOn(observer, "callback")
-  #   expected = "2101cb9b6a511aaeaddbbe09cf70f881ec568d574a2ffd4dabe5ee9820adaa47\
-  #               8e56fd8f4ba5d09ffa1c6d927c40f4c337304049e8a952fbcbf45c6fa77a41a4"
-  #   ImportExport.Crypto_scrypt "pleaseletmein", "SodiumChloride" , 1048576, 8, 1, 64, observer.callback
-  #   expect(observer.callback).toHaveBeenCalled()
-  #   computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-  #   expect(expected).toEqual(computed)
-
-  # The next test vectors for crypto scrypt have been generated using this lib:
-  ## https://hackage.haskell.org/package/scrypt-0.3.2/docs/Crypto-Scrypt.html
-
-  it "haskell generated test vector 1 should work", ->
-    spyOn(observer, "callback")
-    expected = "53019da47bc9fbdc4f719183e08d149bc1cd6b5bf3ab24df8a7c69daed193c69\
-                2d0d56d4c2af3ce3f98a317671bdb40afb15aaf4f08146cffbc4ccdd66817402"
-    ImportExport.Crypto_scrypt "suchCrypto", "soSalty" , 16, 8, 1, 64, observer.callback
-    expect(observer.callback).toHaveBeenCalled()
-    computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-    expect(expected).toEqual(computed)
-
-  it "haskell generated test vector 2 should work", ->
-    spyOn(observer, "callback")
-    expected = "56f5f2c4809f3ab95ecc334e64450392bf6f1f7187653b1ba920f39b4c44b2d6\
-                b47a243c70b2c3444bc31cfec9c57893dd39fa0688bd8a5d1cdcbe08b17b432b"
-    ImportExport.Crypto_scrypt "ΜΟΛΩΝ", "ΛΑΒΕ" , 32, 4, 4, 64, observer.callback
-    expect(observer.callback).toHaveBeenCalled()
-    computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-    expect(expected).toEqual(computed)
-
-  it "haskell generated test vector 3 should work", ->
-    spyOn(observer, "callback")
-    expected = "f890a6beae1dc3f627f9d9bcca8a96950b11758beb1edf1b072c8b8522d15562\
-                9db68aba34619e1ae45b4b6b2917bcb8fd1698b536124df69d5c36d7f28fbe0e"
-    ImportExport.Crypto_scrypt "ϓ␀𐐀💩", "ϓ␀𐐀💩" , 64, 2, 2, 64, observer.callback
-    expect(observer.callback).toHaveBeenCalled()
-    computed = observer.callback.calls.argsFor(0)[0].toString("hex")
-    expect(expected).toEqual(computed)
-################################################################################
 describe "BIP38", ->
 
   observer =
@@ -104,7 +22,7 @@ describe "BIP38", ->
     localStorage.clear()
 
     # mock used inside parseBIP38toECPair
-    spyOn(ImportExport, "Crypto_scrypt").and.callFake(
+    spyOn(WalletCrypto, "scrypt").and.callFake(
       (password, salt, N, r, p, dkLen, callback) ->
         # preimages of Crypto_scrypt
         wrongPassword = "WRONG_PASSWORD" + "e957a24a" + "16384" + "8" + "8" + "64"
@@ -239,7 +157,7 @@ describe "BIP38", ->
 
       ImportExport.parseBIP38toECPair  pk ,pw ,observer.success, observer.wrong_password
 
-      expect(ImportExport.Crypto_scrypt).toHaveBeenCalled()
+      expect(WalletCrypto.scrypt).toHaveBeenCalled()
 
       # Doesn't work:
       # expect(observer.success).toHaveBeenCalledWith(k)

--- a/tests/wallet_crypto_spec.js.coffee
+++ b/tests/wallet_crypto_spec.js.coffee
@@ -168,3 +168,87 @@ describe 'WalletCrypto', ->
 
     it 'should not modify the operation is unknown', ->
       expect(WalletCrypto.cipherFunction('password', 'key', 1000, 'nop')('toto')).toEqual('toto')
+
+  describe "scrypt", ->
+
+    observer =
+      callback: (hash) ->
+
+    beforeEach ->
+  # overrride as a temporary solution
+      window.setTimeout = (myFunction) -> myFunction()
+
+    # Crypto_scrypt test vectors can be found at the end of this document:
+    ## http://www.tarsnap.com/scrypt/scrypt.pdf
+
+    it "Official test vector 1 should work", ->
+      spyOn(observer, "callback")
+      expected = "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442\
+                  fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906"
+      WalletCrypto.scrypt "", "" , 16, 1, 1, 64, observer.callback
+      expect(observer.callback).toHaveBeenCalled()
+      computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+      expect(expected).toEqual(computed)
+
+    # Not using official test vectors 2-4, because they are too slow. Using
+    # Haskell generated test vectors below instead.
+
+    # Disabled because it is too slow
+    # it "Official test vector 2 should work", ->
+    #   spyOn(observer, "callback")
+    #   expected = "fdbabe1c9d3472007856e7190d01e9fe7c6ad7cbc8237830e77376634b3731\
+    #               622eaf30d92e22a3886ff109279d9830dac727afb94a83ee6d8360cbdfa2cc0640"
+    #   ImportExport.Crypto_scrypt "password", "NaCl" , 1024, 8, 16, 64, observer.callback
+    #   expect(observer.callback).toHaveBeenCalled()
+    #   computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+    #   expect(expected).toEqual(computed)
+
+    # Disabled because it is too slow
+    # it "Official test vector 3 should work", ->
+    #   spyOn(observer, "callback")
+    #   expected = "7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2\
+    #               d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887"
+    #   ImportExport.Crypto_scrypt "pleaseletmein", "SodiumChloride", 16384, 8, 1, 64, observer.callback
+    #   expect(observer.callback).toHaveBeenCalled()
+    #   computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+    #   expect(expected).toEqual(computed)
+
+    # Disabled because it is too slow and PhantomJS runs out of memory
+    # it "Official test vector 4 should work", ->
+    #   spyOn(observer, "callback")
+    #   expected = "2101cb9b6a511aaeaddbbe09cf70f881ec568d574a2ffd4dabe5ee9820adaa47\
+    #               8e56fd8f4ba5d09ffa1c6d927c40f4c337304049e8a952fbcbf45c6fa77a41a4"
+    #   ImportExport.Crypto_scrypt "pleaseletmein", "SodiumChloride" , 1048576, 8, 1, 64, observer.callback
+    #   expect(observer.callback).toHaveBeenCalled()
+    #   computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+    #   expect(expected).toEqual(computed)
+
+    # The next test vectors for crypto scrypt have been generated using this lib:
+    ## https://hackage.haskell.org/package/scrypt-0.3.2/docs/Crypto-Scrypt.html
+
+    it "haskell generated test vector 1 should work", ->
+      spyOn(observer, "callback")
+      expected = "53019da47bc9fbdc4f719183e08d149bc1cd6b5bf3ab24df8a7c69daed193c69\
+                  2d0d56d4c2af3ce3f98a317671bdb40afb15aaf4f08146cffbc4ccdd66817402"
+      WalletCrypto.scrypt "suchCrypto", "soSalty" , 16, 8, 1, 64, observer.callback
+      expect(observer.callback).toHaveBeenCalled()
+      computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+      expect(expected).toEqual(computed)
+
+    it "haskell generated test vector 2 should work", ->
+      spyOn(observer, "callback")
+      expected = "56f5f2c4809f3ab95ecc334e64450392bf6f1f7187653b1ba920f39b4c44b2d6\
+                  b47a243c70b2c3444bc31cfec9c57893dd39fa0688bd8a5d1cdcbe08b17b432b"
+      WalletCrypto.scrypt "ΜΟΛΩΝ", "ΛΑΒΕ" , 32, 4, 4, 64, observer.callback
+      expect(observer.callback).toHaveBeenCalled()
+      computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+      expect(expected).toEqual(computed)
+
+    it "haskell generated test vector 3 should work", ->
+      spyOn(observer, "callback")
+      expected = "f890a6beae1dc3f627f9d9bcca8a96950b11758beb1edf1b072c8b8522d15562\
+                  9db68aba34619e1ae45b4b6b2917bcb8fd1698b536124df69d5c36d7f28fbe0e"
+      WalletCrypto.scrypt "ϓ␀𐐀💩", "ϓ␀𐐀💩" , 64, 2, 2, 64, observer.callback
+      expect(observer.callback).toHaveBeenCalled()
+      computed = observer.callback.calls.argsFor(0)[0].toString("hex")
+      expect(expected).toEqual(computed)


### PR DESCRIPTION
iOS references the old `ImportExport.Crypto_scrypt` [here](https://github.com/blockchain/My-Wallet-V3-iOS/blob/ee278f1ff92211a184f88b72da53109830d4a3eb/Blockchain/js/wallet-ios.js#L1279), it needs to be changed to override `WalletCrypto.scrypt`.

Apart from that, I do not see any other code changes to make to other codebases.

Only remains `parseBIP38toECPair` in `ImportExport`. After discussing it with @pernas, moving it to `Address` is the next step to killing import-export.js.