### PR TITLE
blockchain-wallet tests

### DIFF
--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -509,7 +509,7 @@ Wallet.prototype.newLegacyAddress = function (label, pw, success, error) {
 
 Wallet.prototype.deleteLegacyAddress = function (a) {
   assert(a, 'Error: address needed');
-  if (typeof this._addresses === 'object') {
+  if (this.containsLegacyAddress(a)) {
     delete this._addresses[a.address];
     MyWallet.syncWallet();
     return true;


### PR DESCRIPTION
There's a small fix for `deleteLegacyAddress`. It'd call `syncWallet` even when the address to delete wasn't in the wallet.