### PR TITLE
Do not use temporary mnemonic during recovery + cleanup

### DIFF
--- a/src/hd-wallet.js
+++ b/src/hd-wallet.js
@@ -7,7 +7,6 @@ var assert = require('assert');
 var Helpers = require('./helpers');
 var HDAccount = require('./hd-account');
 var BIP39 = require('bip39');
-var RNG = require('./rng');
 var MyWallet = require('./wallet'); // This cyclic import should be avoided once the refactor is complete
 
 // Address class
@@ -150,8 +149,8 @@ function getMasterHex (seedHex, bip39Password, cipher) {
 // load hdwallet
 // restore hdwallet
 
-HDWallet.new = function (cipher) {
-  var mnemonic = BIP39.generateMnemonic(undefined, RNG.run.bind(RNG));
+HDWallet.new = function (mnemonic, bip39Password, cipher) {
+  assert(mnemonic, "BIP 39 mnemonic required")
   var seedHex = BIP39.mnemonicToEntropy(mnemonic);
   return HDWallet.restore(seedHex, '', cipher);
 };
@@ -166,11 +165,11 @@ HDWallet.restore = function (seedHex, bip39Password, cipher) {
     default_account_idx: 0,
     accounts: []
   };
-  var newHDwallet = new HDWallet(hdwallet);
+  var hd = new HDWallet(hdwallet);
   if (cipher) {
-    newHDwallet.encrypt(cipher).persist();
+    hd.encrypt(cipher).persist();
   }
-  return newHDwallet;
+  return hd;
 };
 
 HDWallet.factory = function (o) {

--- a/src/wallet-signup.js
+++ b/src/wallet-signup.js
@@ -6,11 +6,9 @@ var Wallet = require('./blockchain-wallet');
 var Helpers = require('./helpers');
 var WalletNetwork = require('./wallet-network');
 
-function generateNewWallet (password, email, firstAccountName, success, error, isHD, generateUUIDProgress, decryptWalletProgress) {
+function generateNewWallet (password, email, mnemonic, bip39Password, firstAccountName, success, error, generateUUIDProgress, decryptWalletProgress) {
   assert(password.length <= 255, 'Passwords must be shorter than 256 characters');
   assert(!navigator.userAgent.match(/MeeGo/i), 'MeeGo browser currently not supported.'); // User reported this browser generated an invalid private key
-
-  isHD = Helpers.isBoolean(isHD) ? isHD : true;
 
   generateUUIDProgress && generateUUIDProgress();
 
@@ -22,7 +20,6 @@ function generateNewWallet (password, email, firstAccountName, success, error, i
       error('Error generating wallet identifier');
     }
 
-    // Upgrade to HD immediately:
     var saveWallet = function () {
       WalletNetwork.insertWallet(guid, sharedKey, password, {email: email}, decryptWalletProgress).then(function () {
         success(guid, sharedKey, password);
@@ -31,7 +28,7 @@ function generateNewWallet (password, email, firstAccountName, success, error, i
       });
     };
 
-    Wallet.new(guid, sharedKey, firstAccountName, saveWallet, error, isHD);
+    Wallet.new(guid, sharedKey, mnemonic, bip39Password, firstAccountName, saveWallet, error);
   }).catch(error);
 }
 

--- a/tests/hdwallet_spec.js.coffee
+++ b/tests/hdwallet_spec.js.coffee
@@ -1,8 +1,6 @@
 proxyquire = require('proxyquireify')(require)
 MyWallet = undefined
 HDWallet = undefined
-BIP39 = undefined
-RNG = undefined
 
 describe "HDWallet", ->
   wallet = undefined
@@ -117,48 +115,21 @@ describe "HDWallet", ->
     describe "HDWallet.new()", ->
 
       beforeEach ->
-        BIP39 = {
-            generateMnemonic: (str, rng, wlist) ->
-              mnemonic = "bicycle balcony prefer kid flower pole goose crouch century lady worry flavor"
-              seed = rng(32)
-              if seed = "random" then mnemonic else "failure"
-          }
-        RNG = {
-          run: (input) ->
-            if RNG.shouldThrow
-              throw 'Connection failed'
-            "random"
-        }
+
         stubs = {
           './wallet': MyWallet,
-          'bip39': BIP39,
-          './rng' : RNG
         }
-        HDWallet    = proxyquire('../src/hd-wallet', stubs)
-        spyOn(BIP39, "generateMnemonic").and.callThrough()
-        spyOn(RNG, "run").and.callThrough()
 
-      it "should return an hdwallet with a random non-encrypted seedHex", ->
-        hdw = HDWallet.new(null)
+        HDWallet    = proxyquire('../src/hd-wallet', stubs)
+
+      it "should return an hdwallet with the correct non-encrypted seedHex", ->
+        hdw = HDWallet.new("bicycle balcony prefer kid flower pole goose crouch century lady worry flavor" , undefined, null)
         expect(hdw._seedHex).toEqual('15e23aa73d25994f1921a1256f93f72c');
 
       it "should return an hdwallet with a random encrypted seedHex", ->
         encoder = (msg) -> "encrypted-" + msg
-        hdw = HDWallet.new(encoder)
+        hdw = HDWallet.new("bicycle balcony prefer kid flower pole goose crouch century lady worry flavor", undefined, encoder)
         expect(hdw._seedHex).toEqual('encrypted-15e23aa73d25994f1921a1256f93f72c');
-
-      it "should call BIP39.generateMnemonic with our RNG", ->
-
-        hdw = HDWallet.new(null)
-        expect(BIP39.generateMnemonic).toHaveBeenCalled()
-        expect(RNG.run).toHaveBeenCalled()
-
-      it "should throw if RNG throws", ->
-        # E.g. because there was a network failure.
-        # This assumes BIP39.generateMnemonic does not rescue a throw
-        # inside the RNG
-        RNG.shouldThrow = true
-        expect(() -> HDWallet.new(null)).toThrow('Connection failed')
 
     describe "Getter", ->
 

--- a/tests/wallet_signup_spec.js.coffee
+++ b/tests/wallet_signup_spec.js.coffee
@@ -14,7 +14,7 @@ WalletNetwork =
       new Promise((resolve) -> resolve())
 
 Wallet =
-  new: (a, b, c, cb) -> cb()
+  new: (guid, sharedKey, mnemonic, bip39Password, firstAccountLabel, success, error) -> success()
 
 stubs =
   './blockchain-wallet': Wallet
@@ -31,7 +31,7 @@ describe "WalletSignup", ->
 
     it "should not generate a wallet with a password longer than 256 chars", ->
       password = (new Array(1024)).join("x")
-      expect(() -> WalletSignup.generateNewWallet(password, 'a@a.co', 'My Wallet')).toThrow()
+      expect(() -> WalletSignup.generateNewWallet(password, 'a@a.co', undefined, undefined, 'My Wallet')).toThrow()
 
     describe "it should not generate a wallet with bad UUIDs", ->
 
@@ -46,7 +46,7 @@ describe "WalletSignup", ->
         spyOn(observers, "progress")
 
         WalletNetwork.generateBadUUIDs = true
-        WalletSignup.generateNewWallet('pass', 'a@a.co', 'My Wallet', observers.success, observers.error, true, observers.progress)
+        WalletSignup.generateNewWallet('pass', 'a@a.co', undefined, undefined, 'My Wallet', observers.success, observers.error, observers.progress)
 
       it "", ->
         expect(observers.success).not.toHaveBeenCalled()
@@ -69,7 +69,7 @@ describe "WalletSignup", ->
         spyOn(observers, "error").and.callThrough()
         spyOn(observers, "progress")
 
-        WalletSignup.generateNewWallet('totot', 'a@a.co', 'My Wallet', observers.success, observers.error, undefined, observers.progress)
+        WalletSignup.generateNewWallet('totot', 'a@a.co', undefined, undefined, 'My Wallet', observers.success, observers.error, observers.progress)
 
       it "", ->
         expect(observers.success).toHaveBeenCalled()
@@ -91,7 +91,7 @@ describe "WalletSignup", ->
         spyOn(observers, "progress")
 
         WalletNetwork.failInsertion = true
-        WalletSignup.generateNewWallet('totot', 'a@a.co', 'My Wallet', observers.success, observers.error, undefined, observers.progress)
+        WalletSignup.generateNewWallet('totot', 'a@a.co', undefined, undefined, 'My Wallet', observers.success, observers.error, observers.progress)
 
       it "", ->
         expect(observers.success).not.toHaveBeenCalled()


### PR DESCRIPTION
* it is no longer possible to generate a legacy wallet.
* when creating a new wallet the BIP 39 mnemonic is generated in
MyWallet.createNewWallet rather than in HDWallet. This is more
consistent with the recovery process.
* recovery no longer generates a temporary mnemonic and then overrides
it
* added some tests
* clarified some function names
* upgrade function is now called upgradeToV3