### PR TITLE
fix(blockchain-wallet): allow legacy wallets to call balanceActive wi…

### DIFF
--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -249,10 +249,14 @@ Object.defineProperties(Wallet.prototype, {
   'balanceActiveAccounts': {
     configurable: false,
     get: function () {
-      return this.hdwallet.accounts
-                 .filter(function (a) { return !a.archived; })
-                 .map(function (a) { return a.balance; })
-                 .reduce(Helpers.add, 0);
+      if (this.isUpgradedToHD) {
+        return this.hdwallet.accounts
+                  .filter(function (a) { return !a.archived; })
+                  .map(function (a) { return a.balance; })
+                  .reduce(Helpers.add, 0);
+      } else {
+        return 0;
+      }
     }
   },
   'balanceActive': {
@@ -264,11 +268,7 @@ Object.defineProperties(Wallet.prototype, {
   'balanceSpendableActive': {
     configurable: false,
     get: function () {
-      if (this.isUpgradedToHD) {
         return this.balanceSpendableActiveLegacy + this.balanceActiveAccounts;
-      } else {
-        return this.balanceSpendableActiveLegacy;
-      }
     }
   },
   'balanceSpendableActiveLegacy': {


### PR DESCRIPTION
…thout checking for upgrade

This will make it easier to include watch-only addresses in the total balance using balanceActive because it will automatically check whether the wallet is upgraded or not.