### PR TITLE
Fix last remaining issues and force use of semistandard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
 - 5.8
+before_install:
+- npm install -g snazzy
+before_script:
+- node_modules/.bin/semistandard --verbose | snazzy
 script: node_modules/karma/bin/karma start karma.conf.js --single-run && grunt coveralls
 notifications:
   slack:

--- a/package.json
+++ b/package.json
@@ -85,7 +85,9 @@
       "tests/"
     ],
     "globals": [
-      "fetch"
+      "fetch",
+      "XMLHttpRequest",
+      "Audio"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
       "tests/"
     ],
     "globals": [
+      "fetch"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockchain-wallet-client",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Blockchain.info JavaScript Wallet",
   "homepage": "https://github.com/blockchain/my-wallet-v3",
   "bugs": {
@@ -47,8 +47,8 @@
     "ws": "1.1.*"
   },
   "devDependencies": {
-    "browserify": "13.*",
     "babel-polyfill": "^6.7.2",
+    "browserify": "13.*",
     "browserify-istanbul": "^0.2.1",
     "bs58check": "^1.0.5",
     "coffee-script": "~1.8.0",
@@ -77,6 +77,14 @@
     "karma-osx-reporter": "^0.2.0",
     "karma-phantomjs-launcher": "1.0.*",
     "phantomjs-prebuilt": "2.1.*",
-    "proxyquireify": "^2.0.0"
+    "proxyquireify": "^2.0.0",
+    "semistandard": "^8.0.0"
+  },
+  "semistandard": {
+    "ignore": [
+      "tests/"
+    ],
+    "globals": [
+    ]
   }
 }

--- a/src/address.js
+++ b/src/address.js
@@ -188,7 +188,7 @@ Address.fromString = function (keyOrAddr, label, bipPass) {
       var okFormats = ['base58', 'base64', 'hex', 'mini', 'sipa', 'compsipa'];
 
       if (format === 'bip38') {
-        if (bipPass == undefined || bipPass === '') {
+        if (bipPass === undefined || bipPass === null || bipPass === '') {
           return reject('needsBip38');
         }
         ImportExport.parseBIP38toECPair(keyOrAddr, bipPass,

--- a/src/address.js
+++ b/src/address.js
@@ -50,7 +50,7 @@ Object.defineProperties(Address.prototype, {
         this._label = str === '' ? undefined : str;
         MyWallet.syncWallet();
       } else {
-        throw 'Error: address.label must be an alphanumeric string';
+        throw new Error('address.label must be an alphanumeric string');
       }
     }
   },
@@ -73,7 +73,7 @@ Object.defineProperties(Address.prototype, {
       if (Helpers.isPositiveNumber(num)) {
         this._balance = num;
       } else {
-        throw 'Error: address.balance must be a positive number';
+        throw new Error('address.balance must be a positive number');
       }
     }
   },
@@ -84,7 +84,7 @@ Object.defineProperties(Address.prototype, {
       if (Helpers.isPositiveNumber(num)) {
         this._totalSent = num;
       } else {
-        throw 'Error: address.totalSent must be a positive number';
+        throw new Error('address.totalSent must be a positive number');
       }
     }
   },
@@ -95,7 +95,7 @@ Object.defineProperties(Address.prototype, {
       if (Helpers.isPositiveNumber(num)) {
         this._totalReceived = num;
       } else {
-        throw 'Error: address.totalReceived must be a positive number';
+        throw new Error('address.totalReceived must be a positive number');
       }
     }
   },
@@ -124,7 +124,7 @@ Object.defineProperties(Address.prototype, {
         }
         MyWallet.syncWallet();
       } else {
-        throw 'Error: address.archived must be a boolean';
+        throw new Error('address.archived must be a boolean');
       }
     }
   },
@@ -168,7 +168,7 @@ Address.import = function (key, label) {
       object.priv = Base58.encode(key.d.toBuffer(32));
       break;
     default:
-      throw 'Error: address import format not supported';
+      throw new Error('address import format not supported');
   }
 
   // initialization
@@ -232,9 +232,9 @@ Address.prototype.toJSON = function () {
 };
 
 Address.prototype.signMessage = function (message, secondPassword) {
-  if (!Helpers.isString(message)) throw 'Expected message to be a string';
-  if (this.isWatchOnly) throw 'Private key needed for message signing';
-  if (this.isEncrypted && secondPassword == null) throw 'Second password needed to decrypt key';
+  if (!Helpers.isString(message)) throw new Error('Expected message to be a string');
+  if (this.isWatchOnly) throw new Error('Private key needed for message signing');
+  if (this.isEncrypted && secondPassword == null) throw new Error('Second password needed to decrypt key');
 
   var getDecrypted = WalletCrypto.decryptSecretWithSecondPassword.bind(null,
     this.priv, secondPassword, MyWallet.wallet.sharedKey, MyWallet.wallet.pbkdf2_iterations);
@@ -249,7 +249,7 @@ Address.prototype.signMessage = function (message, secondPassword) {
 Address.prototype.encrypt = function (cipher) {
   if (!this._priv) return this;
   var priv = cipher ? cipher(this._priv) : this._priv;
-  if (!priv) { throw 'Error Encoding key'; }
+  if (!priv) { throw new Error('Error Encoding key'); }
   this._temporal_priv = priv;
   return this;
 };
@@ -257,7 +257,7 @@ Address.prototype.encrypt = function (cipher) {
 Address.prototype.decrypt = function (cipher) {
   if (!this._priv) return this;
   var priv = cipher ? cipher(this._priv) : this._priv;
-  if (!priv) { throw 'Error Decoding key'; }
+  if (!priv) { throw new Error('Error Decoding key'); }
   this._temporal_priv = priv;
   return this;
 };

--- a/src/api.js
+++ b/src/api.js
@@ -29,13 +29,12 @@ API.prototype.encodeFormData = function (data) {
   return encoded;
 };
 
-////////////////////////////////////////////////////////////////////////////////
-// Permitted extra headers:
-// sessionToken -> "Authorization Bearer <token>"
+/* Permitted extra headers:
+   sessionToken -> "Authorization Bearer <token>" */
 API.prototype.request = function (action, method, data, extraHeaders) {
-  var url   = this.ROOT_URL + method
-  var body  = data ? this.encodeFormData(data) : ''
-  var time  = (new Date()).getTime();
+  var url = this.ROOT_URL + method;
+  var body = data ? this.encodeFormData(data) : '';
+  var time = (new Date()).getTime();
 
   var options = {
     method: action,
@@ -43,8 +42,8 @@ API.prototype.request = function (action, method, data, extraHeaders) {
     credentials: 'omit'
   };
 
-  if(extraHeaders) {
-    if(extraHeaders.sessionToken) {
+  if (extraHeaders) {
+    if (extraHeaders.sessionToken) {
       options.headers['Authorization'] = 'Bearer ' + extraHeaders.sessionToken;
     }
   }
@@ -172,7 +171,7 @@ API.prototype.getUnspent = function (fromAddresses, confirmations) {
   return this.retry(this.request.bind(this, 'POST', 'unspent', data));
 };
 
-API.prototype.getHistory = function (addresses, tx_filter, offset, n, syncBool) {
+API.prototype.getHistory = function (addresses, txFilter, offset, n, syncBool) {
   var clientTime = (new Date()).getTime();
   offset = offset || 0;
   n = n || 0;
@@ -189,8 +188,8 @@ API.prototype.getHistory = function (addresses, tx_filter, offset, n, syncBool) 
     api_code: this.API_CODE
   };
 
-  if (tx_filter !== undefined && tx_filter !== null) {
-    data.filter = tx_filter;
+  if (txFilter !== undefined && txFilter !== null) {
+    data.filter = txFilter;
   }
   return this.retry(this.request.bind(this, 'POST', 'multiaddr', data, null, syncBool));
 };

--- a/src/api.js
+++ b/src/api.js
@@ -94,7 +94,7 @@ API.prototype.retry = function (f, n) {
   if (i > 1) {
     return f().then(
         undefined, // pass through success
-        function (err) { return self.retry(f, i - 1); }
+        function () { return self.retry(f, i - 1); }
     );
   } else {
     return f();

--- a/src/api.js
+++ b/src/api.js
@@ -200,7 +200,7 @@ API.prototype.securePost = function (url, data) {
   if (!Helpers.isValidGUID(data.guid)) { clone.guid = MyWallet.wallet.guid; }
   if (!data.sharedKey) {
     var sharedKey = MyWallet.wallet ? MyWallet.wallet.sharedKey : undefined;
-    if (!Helpers.isValidSharedKey(sharedKey)) throw 'Shared key is invalid';
+    if (!Helpers.isValidSharedKey(sharedKey)) throw new Error('Shared key is invalid');
     // Rather than sending the shared key plain text
     // send a hash using a totp scheme
     var now = new Date().getTime();

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -6,7 +6,7 @@ var WalletStore = require('./wallet-store.js');
 var MyWallet = require('./wallet.js');
 var API = require('./api');
 
-function get_account_info (success, error) {
+function getAccountInfo (success, error) {
   API.securePostCallbacks('wallet', {method: 'get-info', format: 'json'}, function (data) {
     typeof (success) === 'function' && success(data);
   }, function (data) {
@@ -40,27 +40,27 @@ function updateKV (method, value, success, error, extra) {
  * @param {function ()} success success callback function
  * @param {function ()} error error callback function
  */
-function update_IP_lock (ips, success, error) {
+function updateIPlock (ips, success, error) {
   updateKV('update-ip-lock', ips, success, error);
 }
 
-function update_IP_lock_on (enabled, success, error) {
-  updateKV('update-ip-lock-on', enabled ? true : false, success, error);
+function updateIPlockOn (enabled, success, error) {
+  updateKV('update-ip-lock-on', Boolean(enabled), success, error);
 }
 
-function change_language (language, success, error) {
+function changeLanguage (language, success, error) {
   updateKV('update-language', language, success, error);
 }
 
-function change_local_currency (code, success, error) {
+function changeLocalCurrency (code, success, error) {
   updateKV('update-currency', code, success, error);
 }
 
-function change_btc_currency (code, success, error) {
+function changeBtcCurrency (code, success, error) {
   updateKV('update-btc-currency', code, success, error);
 }
 
-function update_tor_ip_block (enabled, success, error) {
+function updateTorIpBlock (enabled, success, error) {
   updateKV('update-block-tor-ips', enabled ? 1 : 0, success, error);
 }
 
@@ -76,21 +76,21 @@ function isBadPasswordHint (value) {
   }
 }
 
-function update_password_hint1 (value, success, error) {
+function updatePasswordHint1 (value, success, error) {
   assert(error && typeof (error) === 'function', 'Error callback required');
 
   var isBad = isBadPasswordHint(value);
   isBad ? error(isBad) : updateKV('update-password-hint1', value, success, error);
 }
 
-function update_password_hint2 (value, success, error) {
+function updatePasswordHint2 (value, success, error) {
   assert(error && typeof (error) === 'function', 'Error callback required');
 
   var isBad = isBadPasswordHint(value);
   isBad ? error(isBad) : updateKV('update-password-hint2', value, success, error);
 }
 
-function change_email (email, success, error) {
+function changeEmail (email, success, error) {
   updateKV('update-email', email, success, error);
 }
 
@@ -107,7 +107,7 @@ function updateLoggingLevel (val, success, error) {
 }
 
 function toggleSave2FA (val, success, error) {
-  updateKV('update-never-save-auth-type', val ? true : false, success, error);
+  updateKV('update-never-save-auth-type', Boolean(val), success, error);
 }
 
 function updateAuthType (val, success, error) {
@@ -148,8 +148,8 @@ function setTwoFactorEmail (success, error) {
 }
 
 function setTwoFactorGoogleAuthenticator (success, error) {
-  API.securePostCallbacks('wallet', { method: 'generate-google-secret' }, function (google_secret_url) {
-    typeof (success) === 'function' && success(google_secret_url);
+  API.securePostCallbacks('wallet', { method: 'generate-google-secret' }, function (googleSecretURL) {
+    typeof (success) === 'function' && success(googleSecretURL);
   }, function (data) {
     WalletStore.sendEvent('msg', {type: 'error', message: data.responseText});
     typeof (error) === 'function' && error(data.responseText);
@@ -276,16 +276,16 @@ function disableAllNotifications (success, error) {
 }
 
 module.exports = {
-  get_account_info: get_account_info,
-  update_IP_lock: update_IP_lock,
-  update_IP_lock_on: update_IP_lock_on,
-  change_language: change_language,
-  change_local_currency: change_local_currency,
-  change_btc_currency: change_btc_currency,
-  update_tor_ip_block: update_tor_ip_block,
-  update_password_hint1: update_password_hint1,
-  update_password_hint2: update_password_hint2,
-  change_email: change_email,
+  getAccountInfo: getAccountInfo,
+  updateIPlock: updateIPlock,
+  updateIPlockOn: updateIPlockOn,
+  changeLanguage: changeLanguage,
+  changeLocalCurrency: changeLocalCurrency,
+  changeBtcCurrency: changeBtcCurrency,
+  updateTorIpBlock: updateTorIpBlock,
+  updatePasswordHint1: updatePasswordHint1,
+  updatePasswordHint2: updatePasswordHint2,
+  changeEmail: changeEmail,
   changeMobileNumber: changeMobileNumber,
   updateLoggingLevel: updateLoggingLevel,
   toggleSave2FA: toggleSave2FA,

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -18,7 +18,7 @@ function get_account_info (success, error) {
 }
 
 function updateKV (method, value, success, error, extra) {
-  if (typeof value == 'string') {
+  if (typeof value === 'string') {
     value = value.trim();
   }
 

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -103,10 +103,8 @@ Object.defineProperties(Wallet.prototype, {
       switch (true) {
         case !Helpers.isPositiveNumber(value):
           throw new Error('wallet.fee_per_kb must be a positive number');
-          break;
         case value > 1000000:  // 0.01 btc
           throw new Error('wallet.fee_per_kb too high (0.01 btc limit)');
-          break;
         default:
           this._fee_per_kb = value;
           MyWallet.syncWallet();
@@ -519,8 +517,8 @@ Wallet.prototype.deleteLegacyAddress = function (a) {
 Wallet.prototype.validateSecondPassword = function (inputString) {
   // old wallets default_iterations is 10
   var it = !this._pbkdf2_iterations ? 10 : this._pbkdf2_iterations;
-  var password_hash = WalletCrypto.hashNTimes(this._sharedKey + inputString, it);
-  return password_hash === this._dpasswordhash;
+  var passwordHash = WalletCrypto.hashNTimes(this._sharedKey + inputString, it);
+  return passwordHash === this._dpasswordhash;
 };
 
 Wallet.prototype.encrypt = function (pw, success, error, encrypting, syncing) {
@@ -697,7 +695,7 @@ Wallet.prototype.upgradeToV3 = function (firstAccountLabel, pw, success, error) 
     var hd = HDWallet.new(mnemonic, undefined, encoder);
   } catch (e) { error(e); return; }
   this._hd_wallets.push(hd);
-  var label = firstAccountLabel ? firstAccountLabel : 'My Bitcoin Wallet';
+  var label = firstAccountLabel || 'My Bitcoin Wallet';
   this.newAccount(label, pw, this._hd_wallets.length - 1, true);
   MyWallet.syncWallet(function (res) {
     success();

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -261,7 +261,7 @@ Object.defineProperties(Wallet.prototype, {
   'balanceSpendableActive': {
     configurable: false,
     get: function () {
-        return this.balanceSpendableActiveLegacy + this.balanceActiveAccounts;
+      return this.balanceSpendableActiveLegacy + this.balanceActiveAccounts;
     }
   },
   'balanceSpendableActiveLegacy': {
@@ -363,18 +363,18 @@ Wallet.prototype._updateWalletInfo = function (obj) {
   return obj.txs.length;
 };
 
-Wallet.prototype.getHistory = function () {
+Wallet.prototype.getHistory = function () {
   return API.getHistory(this.context, 0, 0, this.txList.loadNumber)
     .then(function (obj) { this.txList.wipe(); return obj; }.bind(this))
     .then(this._updateWalletInfo.bind(this));
 };
 
-Wallet.prototype.fetchTransactions = function () {
+Wallet.prototype.fetchTransactions = function () {
   return API.getHistory(this.context, 0, this.txList.fetched, this.txList.loadNumber)
     .then(this._updateWalletInfo.bind(this));
 };
 
-Wallet.prototype.getBalancesForArchived = function () {
+Wallet.prototype.getBalancesForArchived = function () {
   var updateBalance = function (key) {
     if (this.containsLegacyAddress(key.address)) {
       this.key(key.address).balance = key.final_balance;
@@ -666,7 +666,7 @@ Wallet.prototype.disableNotifications = function (success, error) {
 
 // creating a new wallet object
 Wallet.new = function (guid, sharedKey, mnemonic, bip39Password, firstAccountLabel, success, error) {
-  assert(mnemonic, "BIP 39 mnemonic required")
+  assert(mnemonic, 'BIP 39 mnemonic required');
 
   var object = {
     guid: guid,
@@ -691,7 +691,6 @@ Wallet.new = function (guid, sharedKey, mnemonic, bip39Password, firstAccountLab
 
 // Adds an HD wallet to an existing wallet, used by frontend and iOs
 Wallet.prototype.upgradeToV3 = function (firstAccountLabel, pw, success, error) {
-
   var encoder = WalletCrypto.cipherFunction(pw, this._sharedKey, this._pbkdf2_iterations, 'enc');
   try {
     var mnemonic = BIP39.generateMnemonic(undefined, RNG.run.bind(RNG));

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -102,10 +102,10 @@ Object.defineProperties(Wallet.prototype, {
     set: function (value) {
       switch (true) {
         case !Helpers.isPositiveNumber(value):
-          throw 'Error: wallet.fee_per_kb must be a positive number';
+          throw new Error('wallet.fee_per_kb must be a positive number');
           break;
         case value > 1000000:  // 0.01 btc
-          throw 'Error: wallet.fee_per_kb too high (0.01 btc limit)';
+          throw new Error('wallet.fee_per_kb too high (0.01 btc limit)');
           break;
         default:
           this._fee_per_kb = value;
@@ -124,7 +124,7 @@ Object.defineProperties(Wallet.prototype, {
       if (Helpers.isPositiveNumber(value)) {
         this._totalSent = value;
       } else {
-        throw 'Error: wallet.totalSent must be a positive number';
+        throw new Error('wallet.totalSent must be a positive number');
       }
     }
   },
@@ -135,7 +135,7 @@ Object.defineProperties(Wallet.prototype, {
       if (Helpers.isPositiveNumber(value)) {
         this._totalReceived = value;
       } else {
-        throw 'Error: wallet.totalReceived must be a positive number';
+        throw new Error('wallet.totalReceived must be a positive number');
       }
     }
   },
@@ -146,7 +146,7 @@ Object.defineProperties(Wallet.prototype, {
       if (Helpers.isPositiveNumber(value)) {
         this._finalBalance = value;
       } else {
-        throw 'Error: wallet.finalBalance must be a positive number';
+        throw new Error('wallet.finalBalance must be a positive number');
       }
     }
   },
@@ -161,7 +161,7 @@ Object.defineProperties(Wallet.prototype, {
       if (Helpers.isPositiveInteger(value)) {
         this._numberTxTotal = value;
       } else {
-        throw 'Error: wallet.numberTx must be a positive integer';
+        throw new Error('wallet.numberTx must be a positive integer');
       }
     }
   },
@@ -290,7 +290,7 @@ Object.defineProperties(Wallet.prototype, {
         this._latestBlock = b;
         WalletStore.sendEvent('did_set_latest_block');
       } else {
-        throw 'Error: tried to set wrong wallet.latestBlock';
+        throw new Error('tried to set wrong wallet.latestBlock');
       }
     }
   },
@@ -302,7 +302,7 @@ Object.defineProperties(Wallet.prototype, {
         this._logout_time = t;
         MyWallet.syncWallet();
       } else {
-        throw 'Error: wallet.logoutTime must be a positive integer in range 60000,86400001';
+        throw new Error('wallet.logoutTime must be a positive integer in range 60000,86400001');
       }
     }
   }
@@ -428,14 +428,14 @@ Wallet.prototype.addKeyToLegacyAddress = function (privateKey, addr, secPass, bi
         if (this.key(newKey.address).isWatchOnly) {
           watchOnlyKey = this._addresses[newKey.address];
         } else {
-          throw 'privateKeyOfAnotherNonWatchOnlyAddress';
+          throw new Error('privateKeyOfAnotherNonWatchOnlyAddress');
         }
       }
     }
     watchOnlyKey._priv = newKey._priv;
     if (this.isDoubleEncrypted) {
-      if (!secPass) { throw 'Error: second password needed'; }
-      if (!this.validateSecondPassword(secPass)) { throw 'Error: wrong second password'; }
+      if (!secPass) { throw new Error('second password needed'); }
+      if (!this.validateSecondPassword(secPass)) { throw new Error('wrong second password'); }
       var cipher = WalletCrypto.cipherFunction(secPass, this._sharedKey, this._pbkdf2_iterations, 'enc');
       watchOnlyKey.encrypt(cipher).persist();
     }
@@ -458,12 +458,12 @@ Wallet.prototype.importLegacyAddress = function (addr, label, secPass, bipPass) 
       if (this.key(ad.address).isWatchOnly && !ad.isWatchOnly) {
         return this.addKeyToLegacyAddress(addr, ad.address, secPass, bipPass);
       } else {
-        throw 'presentInWallet';
+        throw new Error('presentInWallet');
       }
     }
     if (this.isDoubleEncrypted) {
-      if (!secPass) { throw 'Error: second password needed'; }
-      if (!this.validateSecondPassword(secPass)) { throw 'Error: wrong second password'; }
+      if (!secPass) { throw new Error('second password needed'); }
+      if (!this.validateSecondPassword(secPass)) { throw new Error('wrong second password'); }
       var cipher = WalletCrypto.cipherFunction(secPass, this._sharedKey, this._pbkdf2_iterations, 'enc');
       ad.encrypt(cipher).persist();
     }

--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -48,7 +48,7 @@ Object.defineProperties(HDAccount.prototype, {
         this._label = str;
         MyWallet.syncWallet();
       } else {
-        throw 'Error: account.label must be an alphanumeric string';
+        throw new Error('account.label must be an alphanumeric string');
       }
     }
   },
@@ -59,7 +59,7 @@ Object.defineProperties(HDAccount.prototype, {
       if (Helpers.isPositiveNumber(num)) {
         this._balance = num;
       } else {
-        throw 'Error: account.balance must be a positive number';
+        throw new Error('account.balance must be a positive number');
       }
     }
   },
@@ -69,7 +69,7 @@ Object.defineProperties(HDAccount.prototype, {
       if (Helpers.isPositiveInteger(num)) {
         this._n_tx = num;
       } else {
-        throw 'Error: account.n_tx must be a positive integer';
+        throw new Error('account.n_tx must be a positive integer');
       }
     }
   },
@@ -85,7 +85,7 @@ Object.defineProperties(HDAccount.prototype, {
           MyWallet.wallet.getHistory();
         }
       } else {
-        throw 'Error: account.archived must be a boolean';
+        throw new Error('account.archived must be a boolean');
       }
     }
   },
@@ -101,7 +101,7 @@ Object.defineProperties(HDAccount.prototype, {
       if (Helpers.isPositiveInteger(value)) {
         this._receiveIndex = value;
       } else {
-        throw 'Error: account.receiveIndex must be a number';
+        throw new Error('account.receiveIndex must be a number');
       }
     }
   },
@@ -112,7 +112,7 @@ Object.defineProperties(HDAccount.prototype, {
       if (Helpers.isPositiveInteger(value)) {
         this._lastUsedReceiveIndex = value;
       } else {
-        throw 'Error: account.lastUsedReceiveIndex must be a number';
+        throw new Error('account.lastUsedReceiveIndex must be a number');
       }
     }
   },
@@ -136,7 +136,7 @@ Object.defineProperties(HDAccount.prototype, {
       if (Helpers.isPositiveInteger(value)) {
         this._changeIndex = value;
       } else {
-        throw 'Error: account.changeIndex must be a number';
+        throw new Error('account.changeIndex must be a number');
       }
     }
   },
@@ -313,7 +313,7 @@ HDAccount.prototype.receiveAddressAtIndex = function (index) {
 HDAccount.prototype.encrypt = function (cipher) {
   if (!this._xpriv) return this;
   var xpriv = cipher ? cipher(this._xpriv) : this._xpriv;
-  if (!xpriv) { throw 'Error Encoding account extended private key'; }
+  if (!xpriv) { throw new Error('Error Encoding account extended private key'); }
   this._temporal_xpriv = xpriv;
   return this;
 };
@@ -321,7 +321,7 @@ HDAccount.prototype.encrypt = function (cipher) {
 HDAccount.prototype.decrypt = function (cipher) {
   if (!this._xpriv) return this;
   var xpriv = cipher ? cipher(this._xpriv) : this._xpriv;
-  if (!xpriv) { throw 'Error Decoding account extended private key'; }
+  if (!xpriv) { throw new Error('Error Decoding account extended private key'); }
   this._temporal_xpriv = xpriv;
   return this;
 };

--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -122,7 +122,7 @@ Object.defineProperties(HDAccount.prototype, {
       var keys = Object.keys(this._address_labels).map(function (k) {
         return parseInt(k, 10);
       });
-      if (keys.length == 0) {
+      if (keys.length === 0) {
         return -1;
       } else {
         return Math.max.apply(null, keys);

--- a/src/hd-wallet.js
+++ b/src/hd-wallet.js
@@ -48,7 +48,7 @@ Object.defineProperties(HDWallet.prototype, {
         this._default_account_idx = value;
         MyWallet.syncWallet();
       } else {
-        throw 'Error: unvalid default index account';
+        throw new Error('unvalid default index account');
       }
     }
   },
@@ -120,7 +120,7 @@ function decryptMnemonic (seedHex, cipher) {
     if (Helpers.isSeedHex(seedHex)) {
       return BIP39.entropyToMnemonic(seedHex);
     } else {
-      throw 'Decryption function needed to get the mnemonic';
+      throw new Error('Decryption function needed to get the mnemonic');
     }
   }
 }

--- a/src/hd-wallet.js
+++ b/src/hd-wallet.js
@@ -148,7 +148,7 @@ function getMasterHex (seedHex, bip39Password, cipher) {
 // restore hdwallet
 
 HDWallet.new = function (mnemonic, bip39Password, cipher) {
-  assert(mnemonic, "BIP 39 mnemonic required")
+  assert(mnemonic, 'BIP 39 mnemonic required');
   var seedHex = BIP39.mnemonicToEntropy(mnemonic);
 
   if (!Helpers.isString(bip39Password)) bip39Password = '';

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,7 +12,7 @@ var Helpers = {};
 Math.log2 = function (x) { return Math.log(x) / Math.LN2; };
 
 Helpers.isString = function (str) {
-  return typeof str == 'string' || str instanceof String;
+  return typeof str === 'string' || str instanceof String;
 };
 Helpers.isKey = function (bitcoinKey) {
   return Helpers.isInstanceOf(bitcoinKey, Bitcoin.ECPair);
@@ -55,13 +55,13 @@ Helpers.isBase64 = function (str) {
   return Helpers.isString(str) && /^[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789=+\/]+$/.test(str);
 };
 Helpers.isNumber = function (num) {
-  return typeof num == 'number' && !isNaN(num);
+  return typeof num === 'number' && !isNaN(num);
 };
 Helpers.isPositiveNumber = function (num) {
   return Helpers.isNumber(num) && num >= 0;
 };
 Helpers.isPositiveInteger = function (num) {
-  return Helpers.isPositiveNumber(num) && num % 1 == 0;
+  return Helpers.isPositiveNumber(num) && num % 1 === 0;
 };
 Helpers.isNotNumber = function (num) {
   return !Helpers.isNumber(num);
@@ -278,20 +278,20 @@ Helpers.privateKeyStringToKey = function (value, format) {
   var key_bytes = null;
   var tbytes;
 
-  if (format == 'base58') {
+  if (format === 'base58') {
     key_bytes = Helpers.buffertoByteArray(Base58.decode(value));
-  } else if (format == 'base64') {
+  } else if (format === 'base64') {
     key_bytes = Helpers.buffertoByteArray(new Buffer(value, 'base64'));
-  } else if (format == 'hex') {
+  } else if (format === 'hex') {
     key_bytes = Helpers.buffertoByteArray(new Buffer(value, 'hex'));
-  } else if (format == 'mini') {
+  } else if (format === 'mini') {
     key_bytes = Helpers.buffertoByteArray(parseMiniKey(value));
-  } else if (format == 'sipa') {
+  } else if (format === 'sipa') {
     tbytes = Helpers.buffertoByteArray(Base58.decode(value));
     tbytes.shift(); // extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
     tbytes.shift();
     key_bytes = tbytes.slice(0, tbytes.length - 4);
-  } else if (format == 'compsipa') {
+  } else if (format === 'compsipa') {
     tbytes = Helpers.buffertoByteArray(Base58.decode(value));
     tbytes.shift(); // extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
     tbytes.shift();
@@ -352,7 +352,7 @@ Helpers.isValidBIP39Mnemonic = function (mnemonic) {
 Helpers.isValidPrivateKey = function (candidate) {
   try {
     var format = Helpers.detectPrivateKeyFormat(candidate);
-    if (format == 'bip38') { return true; }
+    if (format === 'bip38') { return true; }
     var key = Helpers.privateKeyStringToKey(candidate, format);
     return key.getAddress();
   } catch (e) {
@@ -365,7 +365,7 @@ Helpers.privateKeyCorrespondsToAddress = function (address, priv, bipPass) {
     var format = Helpers.detectPrivateKeyFormat(priv);
     var okFormats = ['base58', 'base64', 'hex', 'mini', 'sipa', 'compsipa'];
     if (format === 'bip38') {
-      if (bipPass == undefined || bipPass === '') {
+      if (bipPass === undefined || bipPass === null || bipPass === '') {
         return reject('needsBip38');
       }
       ImportExport.parseBIP38toECPair(priv, bipPass,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -269,7 +269,7 @@ Helpers.buffertoByteArray = function (value) {
 function parseMiniKey (miniKey) {
   var check = Bitcoin.crypto.sha256(miniKey + '?');
   if (check[0] !== 0x00) {
-    throw 'Invalid mini key';
+    throw new Error('Invalid mini key');
   }
   return Bitcoin.crypto.sha256(miniKey);
 }
@@ -298,7 +298,7 @@ Helpers.privateKeyStringToKey = function (value, format) {
     tbytes.pop();
     key_bytes = tbytes.slice(0, tbytes.length - 4);
   } else {
-    throw 'Unsupported Key Format';
+    throw new Error('Unsupported Key Format');
   }
 
   return new Bitcoin.ECPair(new BigInteger.fromByteArrayUnsigned(key_bytes), null, {compressed: format !== 'sipa'});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -98,7 +98,10 @@ Helpers.memoize = function (f) {
   return function () {
     var key = arguments.length + Array.prototype.join.call(arguments, ',');
     if (key in cache) return cache[key];
-    else return cache[key] = f.apply(this, arguments);
+    else {
+      var value = cache[key] = f.apply(this, arguments);
+      return value;
+    }
   };
 };
 
@@ -170,7 +173,7 @@ Helpers.maybeCompose = function (f, g) {
   }
 };
 
-Function.prototype.compose = function (g) {
+Function.prototype.compose = function (g) { // eslint-disable-line no-extend-native
   var fn = this;
   return function () {
     return fn.call(this, g.apply(this, arguments));
@@ -257,7 +260,7 @@ Helpers.tor = function () {
   var hostname = Helpers.getHostName();
 
   // NodeJS TOR detection not supported:
-  if ('string' !== typeof hostname) return null;
+  if (typeof hostname !== 'string') return null;
 
   return hostname.slice(-6) === '.onion';
 };
@@ -275,33 +278,33 @@ function parseMiniKey (miniKey) {
 }
 
 Helpers.privateKeyStringToKey = function (value, format) {
-  var key_bytes = null;
+  var keyBytes = null;
   var tbytes;
 
   if (format === 'base58') {
-    key_bytes = Helpers.buffertoByteArray(Base58.decode(value));
+    keyBytes = Helpers.buffertoByteArray(Base58.decode(value));
   } else if (format === 'base64') {
-    key_bytes = Helpers.buffertoByteArray(new Buffer(value, 'base64'));
+    keyBytes = Helpers.buffertoByteArray(new Buffer(value, 'base64'));
   } else if (format === 'hex') {
-    key_bytes = Helpers.buffertoByteArray(new Buffer(value, 'hex'));
+    keyBytes = Helpers.buffertoByteArray(new Buffer(value, 'hex'));
   } else if (format === 'mini') {
-    key_bytes = Helpers.buffertoByteArray(parseMiniKey(value));
+    keyBytes = Helpers.buffertoByteArray(parseMiniKey(value));
   } else if (format === 'sipa') {
     tbytes = Helpers.buffertoByteArray(Base58.decode(value));
     tbytes.shift(); // extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
     tbytes.shift();
-    key_bytes = tbytes.slice(0, tbytes.length - 4);
+    keyBytes = tbytes.slice(0, tbytes.length - 4);
   } else if (format === 'compsipa') {
     tbytes = Helpers.buffertoByteArray(Base58.decode(value));
     tbytes.shift(); // extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
     tbytes.shift();
     tbytes.pop();
-    key_bytes = tbytes.slice(0, tbytes.length - 4);
+    keyBytes = tbytes.slice(0, tbytes.length - 4);
   } else {
     throw new Error('Unsupported Key Format');
   }
 
-  return new Bitcoin.ECPair(new BigInteger.fromByteArrayUnsigned(key_bytes), null, {compressed: format !== 'sipa'});
+  return new Bitcoin.ECPair(new BigInteger.fromByteArrayUnsigned(keyBytes), null, {compressed: format !== 'sipa'}); // eslint-disable-line new-cap
 };
 
 Helpers.detectPrivateKeyFormat = function (key) {

--- a/src/import-export.js
+++ b/src/import-export.js
@@ -10,7 +10,7 @@ var Buffer = require('buffer').Buffer;
 var hash256 = Bitcoin.crypto.hash256;
 
 var ImportExport = new function () {
-  this.parseBIP38toECPair = function (base58Encrypted, passphrase, success, wrong_password, error) {
+  this.parseBIP38toECPair = function (base58Encrypted, passphrase, success, wrongPassword, error) {
     var hex;
 
     // Unicode NFC normalization
@@ -65,7 +65,7 @@ var ImportExport = new function () {
     }
 
     var decrypted;
-    var AES_opts = { mode: WalletCrypto.AES.ECB, padding: WalletCrypto.pad.NoPadding };
+    var AESopts = { mode: WalletCrypto.AES.ECB, padding: WalletCrypto.pad.NoPadding };
 
     var verifyHashAndReturn = function () {
       var tmpkey = new Bitcoin.ECPair(decrypted, null, {compressed: isCompPoint});
@@ -75,7 +75,7 @@ var ImportExport = new function () {
       checksum = hash256(base58Address);
 
       if (checksum[0] !== hex[3] || checksum[1] !== hex[4] || checksum[2] !== hex[5] || checksum[3] !== hex[6]) {
-        wrong_password();
+        wrongPassword();
         return;
       }
       success(tmpkey, isCompPoint);
@@ -87,7 +87,7 @@ var ImportExport = new function () {
       WalletCrypto.scrypt(passphrase, addresshash, 16384, 8, 8, 64, function (derivedBytes) {
         var k = derivedBytes.slice(32, 32 + 32);
 
-        var decryptedBytes = WalletCrypto.AES.decrypt(Buffer(hex.slice(7, 7 + 32)), k, null, AES_opts);
+        var decryptedBytes = WalletCrypto.AES.decrypt(Buffer(hex.slice(7, 7 + 32)), k, null, AESopts);
         for (var x = 0; x < 32; x++) { decryptedBytes[x] ^= derivedBytes[x]; }
 
         decrypted = BigInteger.fromBuffer(decryptedBytes);
@@ -119,13 +119,13 @@ var ImportExport = new function () {
         WalletCrypto.scrypt(passpoint, addresshashplusownerentropy, 1024, 1, 1, 64, function (derived) {
           var k = derived.slice(32);
 
-          var unencryptedpart2Bytes = WalletCrypto.AES.decrypt(encryptedpart2, k, null, AES_opts);
+          var unencryptedpart2Bytes = WalletCrypto.AES.decrypt(encryptedpart2, k, null, AESopts);
 
           for (var i = 0; i < 16; i++) { unencryptedpart2Bytes[i] ^= derived[i + 16]; }
 
           var encryptedpart1 = Buffer.concat([Buffer(hex.slice(15, 15 + 8)), Buffer(unencryptedpart2Bytes.slice(0, 0 + 8))]);
 
-          var unencryptedpart1Bytes = WalletCrypto.AES.decrypt(encryptedpart1, k, null, AES_opts);
+          var unencryptedpart1Bytes = WalletCrypto.AES.decrypt(encryptedpart1, k, null, AESopts);
 
           for (var ii = 0; ii < 16; ii++) { unencryptedpart1Bytes[ii] ^= derived[ii]; }
 

--- a/src/import-export.js
+++ b/src/import-export.js
@@ -142,7 +142,7 @@ var ImportExport = new function () {
         });
       });
     }
-  }
+  };
 };
 
 module.exports = ImportExport;

--- a/src/import-export.js
+++ b/src/import-export.js
@@ -23,10 +23,10 @@ var ImportExport = new function () {
       return;
     }
 
-    if (hex.length != 43) {
+    if (hex.length !== 43) {
       error('Invalid Private Key');
       return;
-    } else if (hex[0] != 0x01) {
+    } else if (hex[0] !== 0x01) {
       error('Invalid Private Key');
       return;
     }
@@ -36,7 +36,7 @@ var ImportExport = new function () {
 
     var checksum = hash256(hex);
 
-    if (checksum[0] != expChecksum[0] || checksum[1] != expChecksum[1] || checksum[2] != expChecksum[2] || checksum[3] != expChecksum[3]) {
+    if (checksum[0] !== expChecksum[0] || checksum[1] !== expChecksum[1] || checksum[2] !== expChecksum[2] || checksum[3] !== expChecksum[3]) {
       error('Invalid Private Key');
       return;
     }
@@ -44,18 +44,18 @@ var ImportExport = new function () {
     var isCompPoint = false;
     var isECMult = false;
     var hasLotSeq = false;
-    if (hex[1] == 0x42) {
-      if (hex[2] == 0xe0) {
+    if (hex[1] === 0x42) {
+      if (hex[2] === 0xe0) {
         isCompPoint = true;
-      } else if (hex[2] != 0xc0) {
+      } else if (hex[2] !== 0xc0) {
         error('Invalid Private Key');
         return;
       }
-    } else if (hex[1] == 0x43) {
+    } else if (hex[1] === 0x43) {
       isECMult = true;
-      isCompPoint = (hex[2] & 0x20) != 0;
-      hasLotSeq = (hex[2] & 0x04) != 0;
-      if ((hex[2] & 0x24) != hex[2]) {
+      isCompPoint = (hex[2] & 0x20) !== 0;
+      hasLotSeq = (hex[2] & 0x04) !== 0;
+      if ((hex[2] & 0x24) !== hex[2]) {
         error('Invalid Private Key');
         return;
       }
@@ -74,7 +74,7 @@ var ImportExport = new function () {
 
       checksum = hash256(base58Address);
 
-      if (checksum[0] != hex[3] || checksum[1] != hex[4] || checksum[2] != hex[5] || checksum[3] != hex[6]) {
+      if (checksum[0] !== hex[3] || checksum[1] !== hex[4] || checksum[2] !== hex[5] || checksum[3] !== hex[6]) {
         wrong_password();
         return;
       }

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -56,5 +56,5 @@ KeyChain.prototype.getAddress = function (index) {
 KeyChain.prototype.getPrivateKey = function (index) {
   assert(Helpers.isPositiveInteger(index), 'private key index must be integer >= 0');
   var key = this._getKey(index);
-  return key ? key : null;
+  return key || null;
 };

--- a/src/keyring.js
+++ b/src/keyring.js
@@ -37,7 +37,7 @@ KeyRing.prototype.init = function (extendedKey, cache) {
 };
 
 // "M/0/0" -> HDNode
-KeyRing.prototype.privateKeyFromPath = function (path) {
+KeyRing.prototype.privateKeyFromPath = function (path) {
   var components = path.split('/');
   assert(components[0] === 'M', 'Invalid Path prefix');
   assert(components[1] === '0' || components[1] === '1'

--- a/src/payment.js
+++ b/src/payment.js
@@ -334,7 +334,7 @@ Payment.from = function (origin) {
       // this could fail for network issues or no-balance
       function (error) {
         if (error !== 'No free outputs to spend') {
-          that.emit('error', {error:'ERR_FETCH_UNSPENT' });
+          that.emit('error', { error: 'ERR_FETCH_UNSPENT' });
         }
         console.log(error);
         payment.coins = [];

--- a/src/payment.js
+++ b/src/payment.js
@@ -69,7 +69,7 @@ function Payment (payment) {
     txSize: 0 // transaciton size
   };
 
-  var p = payment ? payment : initialState;
+  var p = payment || initialState;
   this.payment = Payment.return(p);
   this.updateFees();
 
@@ -167,7 +167,7 @@ Payment.prototype.printJSON = function () {
 };
 
 Payment.return = function (payment) {
-  var p = payment ? payment : {};
+  var p = payment || {};
   return Promise.resolve(p);
 };
 

--- a/src/payment.js
+++ b/src/payment.js
@@ -438,7 +438,7 @@ Payment.sign = function (password) {
         .then(function (A) { A.archived = true; });
     };
 
-    if (!payment.transaction) throw 'This transaction hasn\'t been built yet';
+    if (!payment.transaction) throw new Error('This transaction hasn\'t been built yet');
     if (Array.isArray(payment.wifKeys) && !payment.fromWatchOnly) payment.wifKeys.forEach(importWIF);
 
     payment.transaction.addPrivateKeys(getPrivateKeys(password, payment));

--- a/src/rng.js
+++ b/src/rng.js
@@ -77,7 +77,7 @@ RNG.prototype.run = function (nBytes) {
   } catch (e) {
     console.log('Error: RNG.run');
     console.log(e);
-    throw 'Error generating the entropy' + e;
+    throw new Error('Error generating the entropy' + e);
   }
 };
 
@@ -112,6 +112,6 @@ RNG.prototype.getServerEntropy = function (nBytes) {
 
     return B;
   } else {
-    throw 'Received not ok status: ' + request.status;
+    throw new Error('Received not ok status: ' + request.status);
   }
 };

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 var satoshi = 100000000; // One satoshi
 var symbol_btc = {code: 'BTC', symbol: 'BTC', name: 'Bitcoin', conversion: satoshi, symbolAppearsAfter: true, local: false}; // Default BTC Currency Symbol object
 var symbol_local = {'conversion': 0, 'symbol': '$', 'name': 'U.S. dollar', 'symbolAppearsAfter': false, 'local': true, 'code': 'USD'}; // Users local currency object
@@ -73,3 +74,4 @@ try {
   }
 } catch (e) {
 }
+/* eslint-enable camelcase */

--- a/src/transaction-list.js
+++ b/src/transaction-list.js
@@ -57,7 +57,7 @@ TransactionList.prototype.pushTxs = function (txs) {
 };
 
 TransactionList.prototype.subscribe = function (listener) {
-  if ('function' !== typeof listener) return;
+  if (typeof listener !== 'function') return;
   this._events.addListener('update', listener);
   return this._events.removeListener.bind(this._events, 'update', listener);
 };

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -20,8 +20,8 @@ var Transaction = function (payment, emitter) {
   if (!Array.isArray(toAddresses) && toAddresses != null) { toAddresses = [toAddresses]; }
   if (!Array.isArray(amounts) && amounts != null) { amounts = [amounts]; }
 
-  assert(toAddresses, 'Missing destination address');
-  assert(amounts, 'Missing amount to pay');
+  assert(toAddresses && toAddresses.length, 'Missing destination address');
+  assert(amounts && amounts.length, 'Missing amount to pay');
 
   this.emitter = emitter;
   this.amount = amounts.reduce(Helpers.add, 0);
@@ -30,7 +30,7 @@ var Transaction = function (payment, emitter) {
   this.addressesOfNeededPrivateKeys = [];
   this.pathsOfNeededPrivateKeys = [];
 
-  assert(toAddresses.length == amounts.length, 'The number of destiny addresses and destiny amounts should be the same.');
+  assert(toAddresses.length === amounts.length, 'The number of destiny addresses and destiny amounts should be the same.');
   assert(this.amount >= BITCOIN_DUST, {error: 'BELOW_DUST_THRESHOLD', amount: this.amount, threshold: BITCOIN_DUST});
   assert(unspentOutputs && unspentOutputs.length > 0, {error: 'NO_UNSPENT_OUTPUTS'});
   var transaction = new Bitcoin.TransactionBuilder();

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -521,7 +521,6 @@ function scrypt (passwd, salt, N, r, p, dkLen, callback) {
   }
 
   callback(pbkdf2(passwd, B, 1, dkLen, ALGO.SHA256));
-
 }
 
 module.exports = {

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -497,7 +497,7 @@ function arraycopy32 (src, srcPos, dest, destPos, length) {
 }
 
 function scrypt (passwd, salt, N, r, p, dkLen, callback) {
-  if (N == 0 || (N & (N - 1)) != 0) throw Error('N must be > 0 and a power of 2');
+  if (N === 0 || (N & (N - 1)) !== 0) throw Error('N must be > 0 and a power of 2');
 
   var MAX_VALUE = 2147483647;
   if (N > MAX_VALUE / 128 / r) throw Error('Parameter N is too large');

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -124,16 +124,16 @@ var AES = {
   }
 };
 
-function encryptWallet (data, password, pbkdf2_iterations, version) {
+function encryptWallet (data, password, pbkdf2Iterations, version) {
   assert(data, 'data missing');
   assert(password, 'password missing');
-  assert(pbkdf2_iterations, 'pbkdf2_iterations missing');
+  assert(pbkdf2Iterations, 'pbkdf2Iterations missing');
   assert(version, 'version missing');
 
   return JSON.stringify({
-    pbkdf2_iterations: pbkdf2_iterations,
+    pbkdf2_iterations: pbkdf2Iterations,
     version: version,
-    payload: encryptDataWithPassword(data, password, pbkdf2_iterations)
+    payload: encryptDataWithPassword(data, password, pbkdf2Iterations)
   });
 }
 
@@ -176,7 +176,7 @@ function decryptWalletSync (data, password) {
     decrypted = decryptWalletV1(data, password);
   } finally {
     assert(decrypted, 'Error decrypting wallet, please check that your password is correct');
-    return decrypted;
+    return decrypted; // eslint-disable-line no-unsafe-finally
   }
 }
 
@@ -237,16 +237,16 @@ function cipherFunction (password, sharedKey, pbkdf2Iterations, operation) {
   }
 }
 
-function encryptSecretWithSecondPassword (base58, password, sharedKey, pbkdf2_iterations) {
-  return encryptDataWithPassword(base58, sharedKey + password, pbkdf2_iterations);
+function encryptSecretWithSecondPassword (base58, password, sharedKey, pbkdf2Iterations) {
+  return encryptDataWithPassword(base58, sharedKey + password, pbkdf2Iterations);
 }
 
-function decryptSecretWithSecondPassword (secret, password, sharedKey, pbkdf2_iterations) {
-  return decryptDataWithPassword(secret, sharedKey + password, pbkdf2_iterations);
+function decryptSecretWithSecondPassword (secret, password, sharedKey, pbkdf2Iterations) {
+  return decryptDataWithPassword(secret, sharedKey + password, pbkdf2Iterations);
 }
 
-function decryptPasswordWithProcessedPin (data, password, pbkdf2_iterations) {
-  return decryptDataWithPassword(data, password, pbkdf2_iterations);
+function decryptPasswordWithProcessedPin (data, password, pbkdf2Iterations) {
+  return decryptDataWithPassword(data, password, pbkdf2Iterations);
 }
 
 function encryptDataWithPassword (data, password, iterations) {
@@ -289,7 +289,7 @@ function stretchPassword (password, salt, iterations, keylen) {
   assert(typeof (sjcl.hash.sha1) === 'function', 'missing sha1, make sure sjcl is configured correctly');
 
   var hmacSHA1 = function (key) {
-    var hasher = new sjcl.misc.hmac(key, sjcl.hash.sha1);
+    var hasher = new sjcl.misc.hmac(key, sjcl.hash.sha1); // eslint-disable-line new-cap
     this.encrypt = hasher.encrypt.bind(hasher);
   };
 
@@ -336,7 +336,7 @@ function smix (B, Bi, r, N, V, XY) {
   arraycopy32(XY, Xi, B, Bi, Yi);
 }
 
-function blockmix_salsa8 (BY, Bi, Yi, r) {
+function blockmix_salsa8 (BY, Bi, Yi, r) { // eslint-disable-line camelcase
   var X = [];
   var i;
 
@@ -361,7 +361,7 @@ function R (a, b) {
   return (a << b) | (a >>> (32 - b));
 }
 
-function salsa20_8 (B) {
+function salsa20_8 (B) { // eslint-disable-line camelcase
   var B32 = new Array(32);
   var x = new Array(32);
   var i;

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -165,7 +165,7 @@ function decryptWalletSync (data, password) {
   }
 
   if (version > SUPPORTED_ENCRYPTION_VERSION) {
-    throw 'Wallet version ' + version + ' not supported.';
+    throw new Error('Wallet version ' + version + ' not supported.');
   }
 
   try {

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -204,7 +204,7 @@ function obtainSessionToken () {
 }
 
 function establishSession (token) {
-  if(token) {
+  if (token) {
     return Promise.resolve(token);
   } else {
     return this.obtainSessionToken();
@@ -252,7 +252,7 @@ function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
 
     var error = function (e) {
        var obj = 'object' === typeof e ? e : JSON.parse(e);
-       if(obj && obj.initial_error && !obj.authorization_required) {
+       if (obj && obj.initial_error && !obj.authorization_required) {
          reject(obj.initial_error);
          return;
        }
@@ -338,7 +338,7 @@ function fetchWalletWithSharedKey (guid, sharedKey) {
   var error = function (e) {
      console.log(e);
      var obj = 'object' === typeof e ? e : JSON.parse(e);
-     if(obj && obj.initial_error) {
+     if (obj && obj.initial_error) {
        reject(obj.initial_error);
        return;
      }

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -257,7 +257,7 @@ function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
          return;
        }
        if (obj.authorization_required) {
-         authorizationRequired().then(function() {
+         authorizationRequired().then(function () {
            callGetWalletEndpoint(guid, null, token).then(success).catch(error);
          })
        }
@@ -382,15 +382,15 @@ function pollForSessionGUID (sessionToken) {
 function getCaptchaImage () {
   var self = this;
   var promise = new Promise(function (resolve, reject) {
-    self.obtainSessionToken().then(function(sessionToken) {
-      var success = function(data) {
+    self.obtainSessionToken().then(function (sessionToken) {
+      var success = function (data) {
         resolve({
           image: data,
           sessionToken: sessionToken
         });
       }
 
-      var error = function(e) {
+      var error = function (e) {
         console.log(e);
         reject(e.initial_error);
       }

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -49,9 +49,9 @@ function generateUUIDs (count) {
  * @param {string} sessionToken.
  */
 // used in the frontend and in iOS
-function resendTwoFactorSms (user_guid, sessionToken) {
-  assert(user_guid, "wallet identifier required");
-  assert(sessionToken, "Session token required");
+function resendTwoFactorSms (userGuid, sessionToken) {
+  assert(userGuid, 'wallet identifier required');
+  assert(sessionToken, 'Session token required');
 
   var data = {
     format: 'json',
@@ -62,7 +62,7 @@ function resendTwoFactorSms (user_guid, sessionToken) {
 
   var headers = {sessionToken: sessionToken};
 
-  return API.request('GET', 'wallet/' + user_guid, data, headers)
+  return API.request('GET', 'wallet/' + userGuid, data, headers)
     .catch(handleError('Could not resend two factor sms'));
 }
 
@@ -163,7 +163,7 @@ function insertWallet (guid, sharedKey, password, extra, decryptWalletProgress) 
     try {
       WalletCrypto.decryptWalletSync(crypted, password);
     } catch (e) {
-      return reject(e);
+      return reject(e.message !== undefined ? e.message : e);
     }
 
     // SHA256 new_checksum verified by server in case of corruption during transit
@@ -319,7 +319,7 @@ function fetchWalletWithSharedKey (guid, sharedKey) {
   var success = function (obj) {
 
     if (!obj.guid) {
-      throw('Server returned null guid.');
+      throw(new Error('Server returned null guid.'));
     }
 
     // Even if Two Factor is enabled, some settings need to be saved here,
@@ -331,7 +331,7 @@ function fetchWalletWithSharedKey (guid, sharedKey) {
     if (obj.payload && obj.payload.length > 0 && obj.payload != 'Not modified') {
       return obj;
     } else {
-      throw('Wallet payload missing, empty or not modified');
+      throw(new Error('Wallet payload missing, empty or not modified'));
     }
   };
 

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -200,7 +200,7 @@ function obtainSessionToken () {
     return data.token;
   };
 
-  return API.request("POST", "sessions").then(processResult);
+  return API.request('POST', 'sessions').then(processResult);
 }
 
 function establishSession (token) {
@@ -216,12 +216,12 @@ function establishSession (token) {
 function callGetWalletEndpoint (guid, sharedKey, sessionToken) {
   var clientTime = (new Date()).getTime();
   var data = { format : 'json', resend_code : null, ct : clientTime, api_code : API.API_CODE };
-  var headers = {}
+  var headers = {};
 
   if (sharedKey) {
     data.sharedKey = sharedKey;
   } else {
-    assert(sessionToken, "Session token required");
+    assert(sessionToken, 'Session token required');
     headers.sessionToken = sessionToken;
   }
   return API.request('GET', 'wallet/' + guid, data, headers);
@@ -229,7 +229,6 @@ function callGetWalletEndpoint (guid, sharedKey, sessionToken) {
 
 function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
   var promise = new Promise(function (resolve, reject) {
-
     var success = function (obj) {
       if (!obj.guid) {
         WalletStore.sendEvent('msg', {type: 'error', message: 'Server returned null guid.'});
@@ -251,19 +250,19 @@ function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
     };
 
     var error = function (e) {
-       var obj = 'object' === typeof e ? e : JSON.parse(e);
-       if (obj && obj.initial_error && !obj.authorization_required) {
-         reject(obj.initial_error);
-         return;
-       }
-       if (obj.authorization_required) {
-         authorizationRequired().then(function () {
-           callGetWalletEndpoint(guid, null, token).then(success).catch(error);
-         })
-       }
+      var obj = 'object' === typeof e ? e : JSON.parse(e);
+      if (obj && obj.initial_error && !obj.authorization_required) {
+        reject(obj.initial_error);
+        return;
+      }
+      if (obj.authorization_required) {
+        authorizationRequired().then(function () {
+          callGetWalletEndpoint(guid, null, token).then(success).catch(error);
+        });
+      }
     };
 
-    callGetWalletEndpoint(guid, null, token).then(success).catch(error)
+    callGetWalletEndpoint(guid, null, token).then(success).catch(error);
   });
   return promise;
 }
@@ -271,8 +270,8 @@ function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
 function  fetchWalletWithTwoFactor (guid, sessionToken, twoFactor) {
   var promise = new Promise(function (resolve, reject) {
     if (twoFactor.code.length === 0 || twoFactor.code.length > 255) {
-     reject('You must enter a Two Factor Authentication code');
-     return;
+      reject('You must enter a Two Factor Authentication code');
+      return;
     }
 
     var two_factor_auth_key = twoFactor.code;
@@ -282,20 +281,20 @@ function  fetchWalletWithTwoFactor (guid, sessionToken, twoFactor) {
       case 4: // sms
       case 5: // Google Auth
         two_factor_auth_key = two_factor_auth_key.toUpperCase();
-      break;
+        break;
     }
 
     var success = function (data) {
-     if (data == null || data.length === 0) {
-       otherError('Server Return Empty Wallet Data');
-       return;
-     }
-     if (data !== 'Not modified') { WalletStore.setEncryptedWalletData(data); }
-     resolve(data);
+      if (data == null || data.length === 0) {
+        otherError('Server Return Empty Wallet Data');
+        return;
+      }
+      if (data !== 'Not modified') { WalletStore.setEncryptedWalletData(data); }
+      resolve(data);
     };
     var error = function (response) {
-     WalletStore.setRestoringWallet(false);
-     reject(response);
+      WalletStore.setRestoringWallet(false);
+      reject(response);
     };
 
     var myData = {
@@ -315,9 +314,7 @@ function  fetchWalletWithTwoFactor (guid, sessionToken, twoFactor) {
 }
 
 function fetchWalletWithSharedKey (guid, sharedKey) {
-
   var success = function (obj) {
-
     if (!obj.guid) {
       throw(new Error('Server returned null guid.'));
     }
@@ -336,17 +333,17 @@ function fetchWalletWithSharedKey (guid, sharedKey) {
   };
 
   var error = function (e) {
-     console.log(e);
-     var obj = 'object' === typeof e ? e : JSON.parse(e);
-     if (obj && obj.initial_error) {
-       reject(obj.initial_error);
-       return;
-     }
+    console.log(e);
+    var obj = 'object' === typeof e ? e : JSON.parse(e);
+    if (obj && obj.initial_error) {
+      reject(obj.initial_error);
+      return;
+    }
 
-     WalletStore.sendEvent('did_fail_set_guid');
+    WalletStore.sendEvent('did_fail_set_guid');
   };
 
-  return callGetWalletEndpoint(guid, sharedKey).then(success).catch(error)
+  return callGetWalletEndpoint(guid, sharedKey).then(success).catch(error);
 }
 
 function pollForSessionGUID (sessionToken) {
@@ -359,7 +356,7 @@ function pollForSessionGUID (sessionToken) {
       if (obj.guid) {
         WalletStore.setIsPolling(false);
         WalletStore.sendEvent('msg', {type: 'success', message: 'Authorization Successful'});
-        resolve()
+        resolve();
       } else {
         if (WalletStore.getCounter() < 600) {
           WalletStore.incrementCounter();
@@ -370,14 +367,14 @@ function pollForSessionGUID (sessionToken) {
           WalletStore.setIsPolling(false);
         }
       }
-    }
+    };
     var error = function () {
       WalletStore.setIsPolling(false);
-    }
+    };
     API.request('GET', 'wallet/poll-for-session-guid', data, headers).then(success).catch(error);
   });
   return promise;
-};
+}
 
 function getCaptchaImage () {
   var self = this;
@@ -388,12 +385,12 @@ function getCaptchaImage () {
           image: data,
           sessionToken: sessionToken
         });
-      }
+      };
 
       var error = function (e) {
         console.log(e);
         reject(e.initial_error);
-      }
+      };
 
       var data = {
         timestamp: new Date().getTime()
@@ -405,8 +402,7 @@ function getCaptchaImage () {
     });
   });
   return promise;
-};
-
+}
 
 module.exports = {
   checkWalletChecksum: checkWalletChecksum,

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -33,7 +33,7 @@ function generateUUIDs (count) {
   };
 
   var extractUUIDs = function (data) {
-    if (!data.uuids || data.uuids.length != count) {
+    if (!data.uuids || data.uuids.length !== count) {
       return Promise.reject('Could not generate uuids');
     }
     return data.uuids;
@@ -94,7 +94,7 @@ function checkWalletChecksum (payload_checksum, success, error) {
   var data = {method: 'wallet.aes.json', format: 'json', checksum: payload_checksum};
 
   API.securePostCallbacks('wallet', data, function (obj) {
-    if (!obj.payload || obj.payload == 'Not modified') {
+    if (!obj.payload || obj.payload === 'Not modified') {
       if (success) success();
     } else if (error) error();
   }, function () {
@@ -153,7 +153,7 @@ function insertWallet (guid, sharedKey, password, extra, decryptWalletProgress) 
     // Everything looks ok, Encrypt the JSON output
     var crypted = WalletCrypto.encryptWallet(data, password, MyWallet.wallet.defaultPbkdf2Iterations, MyWallet.wallet.isUpgradedToHD ? 3.0 : 2.0);
 
-    if (crypted.length == 0) {
+    if (crypted.length === 0) {
       return reject('Error encrypting the JSON output');
     }
 
@@ -243,7 +243,7 @@ function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
       WalletStore.setRealAuthType(obj.real_auth_type);
       WalletStore.setSyncPubKeys(obj.sync_pubkeys);
 
-      if (obj.payload && obj.payload.length > 0 && obj.payload != 'Not modified') {
+      if (obj.payload && obj.payload.length > 0 && obj.payload !== 'Not modified') {
         resolve(obj);
       } else {
         needsTwoFactorCode(obj.auth_type);
@@ -270,7 +270,7 @@ function fetchWallet (guid, token, needsTwoFactorCode, authorizationRequired) {
 
 function  fetchWalletWithTwoFactor (guid, sessionToken, twoFactor) {
   var promise = new Promise(function (resolve, reject) {
-    if (twoFactor.code.length == 0 || twoFactor.code.length > 255) {
+    if (twoFactor.code.length === 0 || twoFactor.code.length > 255) {
      reject('You must enter a Two Factor Authentication code');
      return;
     }
@@ -286,11 +286,11 @@ function  fetchWalletWithTwoFactor (guid, sessionToken, twoFactor) {
     }
 
     var success = function (data) {
-     if (data == null || data.length == 0) {
+     if (data == null || data.length === 0) {
        otherError('Server Return Empty Wallet Data');
        return;
      }
-     if (data != 'Not modified') { WalletStore.setEncryptedWalletData(data); }
+     if (data !== 'Not modified') { WalletStore.setEncryptedWalletData(data); }
      resolve(data);
     };
     var error = function (response) {
@@ -328,7 +328,7 @@ function fetchWalletWithSharedKey (guid, sharedKey) {
     WalletStore.setRealAuthType(obj.real_auth_type);
     WalletStore.setSyncPubKeys(obj.sync_pubkeys);
 
-    if (obj.payload && obj.payload.length > 0 && obj.payload != 'Not modified') {
+    if (obj.payload && obj.payload.length > 0 && obj.payload !== 'Not modified') {
       return obj;
     } else {
       throw(new Error('Wallet payload missing, empty or not modified'));

--- a/src/wallet-signup.js
+++ b/src/wallet-signup.js
@@ -3,7 +3,6 @@
 var assert = require('assert');
 
 var Wallet = require('./blockchain-wallet');
-var Helpers = require('./helpers');
 var WalletNetwork = require('./wallet-network');
 
 function generateNewWallet (password, email, mnemonic, bip39Password, firstAccountName, success, error, generateUUIDProgress, decryptWalletProgress) {

--- a/src/wallet-signup.js
+++ b/src/wallet-signup.js
@@ -16,7 +16,7 @@ function generateNewWallet (password, email, mnemonic, bip39Password, firstAccou
     var guid = uuids[0];
     var sharedKey = uuids[1];
 
-    if (guid.length != 36 || sharedKey.length != 36) {
+    if (guid.length !== 36 || sharedKey.length !== 36) {
       error('Error generating wallet identifier');
     }
 

--- a/src/wallet-store.js
+++ b/src/wallet-store.js
@@ -71,7 +71,7 @@ var WalletStore = (function () {
       return WalletCrypto.sha256(encrypted_wallet_data).toString('hex');
     },
     setEncryptedWalletData: function (data) {
-      if (!data || data.length == 0) {
+      if (!data || data.length === 0) {
         encrypted_wallet_data = null;
         payload_checksum = null;
       } else {

--- a/src/wallet-store.js
+++ b/src/wallet-store.js
@@ -7,25 +7,25 @@ var WalletStore = (function () {
   var password; // Password
   var guid; // Wallet identifier
   var language = 'en';
-  var pbkdf2_iterations = 5000; // pbkdf2_interations of the main password (to encrypt the full payload)
-  var disable_logout = false;
-  var real_auth_type = 0; // The real two factor authentication. Even if there is a problem with the current one (for example error 2FA sending email).
-  var encrypted_wallet_data; // Encrypted wallet data (Base64, AES 256)
-  var payload_checksum; // SHA256 hash of the current wallet.aes.json
+  var pbkdf2Iterations = 5000; // pbkdf2_interations of the main password (to encrypt the full payload)
+  var disableLogout = false;
+  var realAuthType = 0; // The real two factor authentication. Even if there is a problem with the current one (for example error 2FA sending email).
+  var encryptedWalletData; // Encrypted wallet data (Base64, AES 256)
+  var payloadChecksum; // SHA256 hash of the current wallet.aes.json
   var isPolling = false;
   var isRestoringWallet = false;
   var counter = 0;
-  var sync_pubkeys = false;
+  var syncPubkeys = false;
   var isSynchronizedWithServer = true;
-  var event_listeners = []; // Emits Did decrypt wallet event (used on claim page)
+  var eventListeners = []; // Emits Did decrypt wallet event (used on claim page)
 
   return {
     setPbkdf2Iterations: function (iterations) {
-      pbkdf2_iterations = iterations;
+      pbkdf2Iterations = iterations;
       return;
     },
     getPbkdf2Iterations: function () {
-      return pbkdf2_iterations;
+      return pbkdf2Iterations;
     },
     getLanguage: function () {
       return language;
@@ -34,23 +34,23 @@ var WalletStore = (function () {
       language = lan;
     },
     disableLogout: function () {
-      disable_logout = true;
+      disableLogout = true;
     },
     enableLogout: function () {
-      disable_logout = false;
+      disableLogout = false;
     },
     isLogoutDisabled: function () {
-      return disable_logout;
+      return disableLogout;
     },
     setRealAuthType: function (number) {
-      real_auth_type = number;
+      realAuthType = number;
     },
     get2FAType: function () {
-      return real_auth_type;
+      return realAuthType;
     },
     get2FATypeString: function () {
       var stringType = '';
-      switch (real_auth_type) {
+      switch (realAuthType) {
         case 0: stringType = null; break;
         case 1: stringType = 'Yubikey'; break;
         case 2: stringType = 'Email'; break;
@@ -68,25 +68,25 @@ var WalletStore = (function () {
       guid = stringValue;
     },
     generatePayloadChecksum: function () {
-      return WalletCrypto.sha256(encrypted_wallet_data).toString('hex');
+      return WalletCrypto.sha256(encryptedWalletData).toString('hex');
     },
     setEncryptedWalletData: function (data) {
       if (!data || data.length === 0) {
-        encrypted_wallet_data = null;
-        payload_checksum = null;
+        encryptedWalletData = null;
+        payloadChecksum = null;
       } else {
-        encrypted_wallet_data = data;
-        payload_checksum = this.generatePayloadChecksum();
+        encryptedWalletData = data;
+        payloadChecksum = this.generatePayloadChecksum();
       }
     },
     getEncryptedWalletData: function () {
-      return encrypted_wallet_data;
+      return encryptedWalletData;
     },
     getPayloadChecksum: function () {
-      return payload_checksum;
+      return payloadChecksum;
     },
     setPayloadChecksum: function (value) {
-      payload_checksum = value;
+      payloadChecksum = value;
     },
     isPolling: function () {
       return isPolling;
@@ -107,10 +107,10 @@ var WalletStore = (function () {
       return counter;
     },
     setSyncPubKeys: function (bool) {
-      sync_pubkeys = bool;
+      syncPubkeys = bool;
     },
     isSyncPubKeys: function () {
-      return sync_pubkeys;
+      return syncPubkeys;
     },
     isSynchronizedWithServer: function () {
       return isSynchronizedWithServer;
@@ -119,18 +119,18 @@ var WalletStore = (function () {
       isSynchronizedWithServer = bool;
     },
     addEventListener: function (func) {
-      event_listeners.push(func);
+      eventListeners.push(func);
     },
-    sendEvent: function (event_name, obj) {
-      for (var listener in event_listeners) {
-        event_listeners[listener](event_name, obj);
+    sendEvent: function (eventName, obj) {
+      for (var listener in eventListeners) {
+        eventListeners[listener](eventName, obj);
       }
     },
     isCorrectMainPassword: function (candidate) {
       return password === candidate;
     },
-    changePassword: function (new_password, success, error) {
-      password = new_password;
+    changePassword: function (newPassword, success, error) {
+      password = newPassword;
       MyWallet.syncWallet(success, error);
     },
     unsafeSetPassword: function (newPassword) {
@@ -140,10 +140,10 @@ var WalletStore = (function () {
       return password;
     },
     getLogoutTime: function () {
-      return MyWallet.wallet._logout_time;
+      return MyWallet.wallet._logoutTime;
     },
-    setLogoutTime: function (logout_time) {
-      MyWallet.wallet.logoutTime = logout_time;
+    setLogoutTime: function (logoutTime) {
+      MyWallet.wallet.logoutTime = logoutTime;
     }
   };
 })();

--- a/src/wallet-transaction.js
+++ b/src/wallet-transaction.js
@@ -7,11 +7,11 @@ var MyWallet = require('./wallet');
 function Tx (object) {
   var obj = object || {};
   // original properties
-  var setConfirmations = function (tx_block_height) {
+  var setConfirmations = function (txBlockHeight) {
     var lastBlock = MyWallet.wallet.latestBlock;
     var conf = 0;
-    if (lastBlock && tx_block_height != null && tx_block_height > 0) {
-      conf = lastBlock.height - tx_block_height + 1;
+    if (lastBlock && txBlockHeight != null && txBlockHeight > 0) {
+      conf = lastBlock.height - txBlockHeight + 1;
     }
     return conf;
   };

--- a/src/wallet-transaction.js
+++ b/src/wallet-transaction.js
@@ -111,7 +111,7 @@ function procIns (acc, input) {
 }
 
 function belongsTo (tx, id) {
-  return tx.processedInputs.concat(tx.processedOutputs).some(function (p) { return p.identity == id; });
+  return tx.processedInputs.concat(tx.processedOutputs).some(function (p) { return p.identity === id; });
 }
 // var memoizedBelongsTo = Helpers.memoize(belongsTo);
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -43,24 +43,24 @@ function socketConnect () {
       return;
     }
 
-    if (obj.op == 'on_change') {
+    if (obj.op === 'on_change') {
       var old_checksum = WalletStore.generatePayloadChecksum();
       var new_checksum = obj.checksum;
 
-      if (last_on_change != new_checksum && old_checksum != new_checksum) {
+      if (last_on_change !== new_checksum && old_checksum !== new_checksum) {
         last_on_change = new_checksum;
 
         MyWallet.getWallet();
       }
-    } else if (obj.op == 'utx') {
+    } else if (obj.op === 'utx') {
       WalletStore.sendEvent('on_tx_received');
       var sendOnTx = WalletStore.sendEvent.bind(null, 'on_tx');
       MyWallet.wallet.getHistory().then(sendOnTx);
-    } else if (obj.op == 'block') {
+    } else if (obj.op === 'block') {
       var sendOnBlock = WalletStore.sendEvent.bind(null, 'on_block');
       MyWallet.wallet.getHistory().then(sendOnBlock);
       MyWallet.wallet.latestBlock = obj.x;
-    } else if (obj.op == 'pong') {
+    } else if (obj.op === 'pong') {
       clearTimeout(MyWallet.ws.pingTimeoutPID);
     }
   }
@@ -95,7 +95,7 @@ MyWallet.getWallet = function (success, error) {
   }
 
   API.securePostCallbacks('wallet', data, function (obj) {
-    if (!obj.payload || obj.payload == 'Not modified') {
+    if (!obj.payload || obj.payload === 'Not modified') {
       if (success) success();
       return;
     }
@@ -122,7 +122,7 @@ MyWallet.decryptAndInitializeWallet = function(success, error, decrypt_success, 
   assert(error, 'Error callback required');
   var encryptedWalletData = WalletStore.getEncryptedWalletData();
 
-  if (encryptedWalletData == null || encryptedWalletData.length == 0) {
+  if (encryptedWalletData === undefined || encryptedWalletData === null || encryptedWalletData.length === 0) {
     error('No Wallet Data To Decrypt');
     return;
   }
@@ -143,7 +143,8 @@ MyWallet.decryptAndInitializeWallet = function(success, error, decrypt_success, 
         WalletStore.setPbkdf2Iterations(rootContainer.pbkdf2_iterations);
       }
       // If we don't have a checksum then the wallet is probably brand new - so we can generate our own
-      if (WalletStore.getPayloadChecksum() == null || WalletStore.getPayloadChecksum().length == 0) {
+      var checkSum = WalletStore.getPayloadChecksum();
+      if (checkSum === undefined || checkSum === null || checkSum.length === 0) {
         WalletStore.setPayloadChecksum(WalletStore.generatePayloadChecksum());
       }
       if (MyWallet.wallet.isUpgradedToHD === false) {
@@ -275,11 +276,11 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
 }
 
 MyWallet.didFetchWallet = function(obj) {
-  if (obj.payload && obj.payload.length > 0 && obj.payload != 'Not modified') {
+  if (obj.payload && obj.payload.length > 0 && obj.payload !== 'Not modified') {
    WalletStore.setEncryptedWalletData(obj.payload);
   }
 
-  if (obj.language && WalletStore.getLanguage() != obj.language) {
+  if (obj.language && WalletStore.getLanguage() !== obj.language) {
    WalletStore.setLanguage(obj.language);
   }
 
@@ -369,7 +370,7 @@ function syncWallet (successcallback, errorcallback) {
     var crypted = WalletCrypto.encryptWallet(data, WalletStore.getPassword(),
         WalletStore.getPbkdf2Iterations(), MyWallet.wallet.isUpgradedToHD ? 3.0 : 2.0);
 
-    if (crypted.length == 0) {
+    if (crypted.length === 0) {
       throw new Error('Error encrypting the JSON output');
     }
 
@@ -396,8 +397,8 @@ function syncWallet (successcallback, errorcallback) {
         if (WalletStore.isSyncPubKeys()) {
           // Include HD addresses unless in lame mode:
           var hdAddresses = (
-            MyWallet.wallet.hdwallet != undefined &&
-            MyWallet.wallet.hdwallet.accounts != undefined
+            MyWallet.wallet.hdwallet !== undefined &&
+            MyWallet.wallet.hdwallet.accounts !== undefined
           ) ? [].concat.apply([],
             MyWallet.wallet.hdwallet.accounts.map(function (account) {
               return account.labeledReceivingAddresses;

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -155,7 +155,7 @@ MyWallet.decryptAndInitializeWallet = function (success, error, decrypt_success,
     },
     error
   );
-}
+};
 
 // used in the frontend
 MyWallet.makePairingCode = function (success, error) {
@@ -206,7 +206,7 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
               reject(e);
             });
           });
-        })
+        });
     } else {
       // Estabish a session to enable 2FA and browser verification:
       WalletNetwork.establishSession(credentials.sessionToken)
@@ -246,7 +246,6 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
           }).catch(function (e) {
             callbacks.wrongTwoFactorCode(e);
           });
-
         } else {
           // Try without 2FA:
           WalletNetwork.fetchWallet(guid, token, needsTwoFactorCode, authorizationRequired)
@@ -263,32 +262,30 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
             reject(e);
           });
         }
-
       }).catch(function (error) {
         console.log(error.message);
-        reject("Unable to establish session");
+        reject('Unable to establish session');
       });
     }
   });
 
   return loginPromise;
-}
+};
 
 MyWallet.didFetchWallet = function (obj) {
   if (obj.payload && obj.payload.length > 0 && obj.payload !== 'Not modified') {
-   WalletStore.setEncryptedWalletData(obj.payload);
+    WalletStore.setEncryptedWalletData(obj.payload);
   }
 
   if (obj.language && WalletStore.getLanguage() !== obj.language) {
-   WalletStore.setLanguage(obj.language);
+    WalletStore.setLanguage(obj.language);
   }
 
   return Promise.resolve();
-}
+};
 
 MyWallet.initializeWallet = function (pw, decrypt_success, build_hd_success) {
   var promise = new Promise(function (resolve, reject) {
-
     if (isInitialized || WalletStore.isRestoringWallet()) {
       return;
     }
@@ -366,8 +363,12 @@ function syncWallet (successcallback, errorcallback) {
   try {
     var method = 'update';
     var data = JSON.stringify(MyWallet.wallet, null, 2);
-    var crypted = WalletCrypto.encryptWallet(data, WalletStore.getPassword(),
-        WalletStore.getPbkdf2Iterations(), MyWallet.wallet.isUpgradedToHD ? 3.0 : 2.0);
+    var crypted = WalletCrypto.encryptWallet(
+      data,
+      WalletStore.getPassword(),
+      WalletStore.getPbkdf2Iterations(),
+      MyWallet.wallet.isUpgradedToHD ? 3.0 : 2.0
+    );
 
     if (crypted.length === 0) {
       throw new Error('Error encrypting the JSON output');
@@ -494,7 +495,6 @@ MyWallet.createNewWallet = function (inputedEmail, inputedPassword, firstAccount
 // used on frontend
 MyWallet.recoverFromMnemonic = function (inputedEmail, inputedPassword, mnemonic, bip39Password, successCallback, error, startedRestoreHDWallet, accountProgress, generateUUIDProgress, decryptWalletProgress) {
   var walletGenerated = function (wallet) {
-
     var saveWallet = function () {
       WalletNetwork.insertWallet(wallet.guid, wallet.sharedKey, inputedPassword, {email: inputedEmail}, decryptWalletProgress).then(function () {
         successCallback({guid: wallet.guid, sharedKey: wallet.sharedKey, password: inputedPassword});
@@ -512,8 +512,9 @@ MyWallet.recoverFromMnemonic = function (inputedEmail, inputedPassword, mnemonic
 
 // used frontend and mywallet
 MyWallet.logout = function (sessionToken, force) {
-  if (!force && WalletStore.isLogoutDisabled())
+  if (!force && WalletStore.isLogoutDisabled()) {
     return;
+  }
 
   var reload = function () {
     try { window.location.reload(); } catch (e) {
@@ -525,7 +526,7 @@ MyWallet.logout = function (sessionToken, force) {
 
   var headers = {sessionToken: sessionToken};
 
-  API.request("GET", 'wallet/logout', data, headers).then(reload).catch(reload);
+  API.request('GET', 'wallet/logout', data, headers).then(reload).catch(reload);
 };
 
 // In case of a non-mainstream browser, ensure it correctly implements the
@@ -537,7 +538,7 @@ MyWallet.browserCheck = function () {
   var account = masterkey.deriveHardened(44).deriveHardened(0).deriveHardened(0);
   var address = account.derive(0).derive(0).getAddress();
   return address === '1QBWUDG4AFL2kFmbqoZ9y4KsSpQoCTZKRw';
-}
+};
 
 MyWallet.browserCheckFast = function () {
   var seed = Buffer('9f3ad67c5f1eebbffcc8314cb8a3aacbfa28046fd4b3d0af6965a8c804a603e57f5b551320eca4017267550e5b01e622978c133f2085c5999f7ef57a340d0ae2', 'hex');
@@ -547,4 +548,4 @@ MyWallet.browserCheckFast = function () {
   hmacSha512.update('100 bottles of beer on the wall');
   var hmacSha512Output = hmacSha512.digest().toString('hex');
   return hmacSha512Output === hmacSha512Expected;
-}
+};

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -135,7 +135,7 @@ MyWallet.decryptAndInitializeWallet = function(success, error, decrypt_success, 
 
       // this sanity check should be done on the load
       // if (!sharedKey || sharedKey.length == 0 || sharedKey.length != 36) {
-      //   throw 'Shared Key is invalid';
+      //   throw new Error('Shared Key is invalid');
       // }
 
       // TODO: pbkdf2 iterations should be stored correctly on wallet wrapper
@@ -338,7 +338,7 @@ function syncWallet (successcallback, errorcallback) {
   var panic = function (e) {
     console.log('Panic ' + e);
     window.location.replace('/');
-    throw 'Save disabled.';
+    throw new Error('Save disabled.');
     // kick out of the wallet in a inconsistent state to prevent save
   };
 
@@ -349,7 +349,7 @@ function syncWallet (successcallback, errorcallback) {
   if (!MyWallet.wallet || !MyWallet.wallet.sharedKey ||
       MyWallet.wallet.sharedKey.length === 0 ||
       MyWallet.wallet.sharedKey.length !== 36) {
-    throw 'Cannot backup wallet now. Shared key is not set';
+    throw new Error('Cannot backup wallet now. Shared key is not set');
   }
 
   WalletStore.disableLogout();
@@ -370,7 +370,7 @@ function syncWallet (successcallback, errorcallback) {
         WalletStore.getPbkdf2Iterations(), MyWallet.wallet.isUpgradedToHD ? 3.0 : 2.0);
 
     if (crypted.length == 0) {
-      throw 'Error encrypting the JSON output';
+      throw new Error('Error encrypting the JSON output');
     }
 
     // Now Decrypt the it again to double check for any possible corruption
@@ -439,7 +439,7 @@ function syncWallet (successcallback, errorcallback) {
       }
     }, function (e) {
       console.log(e);
-      throw 'Decryption failed';
+      throw new Error('Decryption failed');
     });
   } catch (e) {
     _errorcallback(e);

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -489,7 +489,7 @@ MyWallet.createNewWallet = function (inputedEmail, inputedPassword, firstAccount
   try {
     var mnemonic = BIP39.generateMnemonic(undefined, RNG.run.bind(RNG));
     WalletSignup.generateNewWallet(inputedPassword, inputedEmail, mnemonic, undefined, firstAccountName, saveWallet, errorCallback);
-  } catch(e) {
+  } catch (e) {
     errorCallback(e);
   }
 };

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -172,19 +172,18 @@ MyWallet.makePairingCode = function (success, error) {
   }
 };
 
-////////////////////////////////////////////////////////////////////////////////
-// guid: the wallet identifier
-// password: to decrypt the wallet (which happens in the browser)
-// server credentials:
-//   twoFactor: 2FA {type: ..., code: ....} or null
-//   sharedKey: if present, it bypasses 2FA and browser verification
-// callbacks:
-//   needsTwoFactorCode
-//   wrongTwoFactorCode
-//   authorizationRequired: this is a new browser
-//   didFetch: wallet has been downloaded from the server
-//   didDecrypt wallet has been decrypted (with the password)
-//   didBuildHD: HD part of wallet has been constructed in memory
+/* guid: the wallet identifier
+   password: to decrypt the wallet (which happens in the browser)
+   server credentials:
+     twoFactor: 2FA {type: ..., code: ....} or null
+     sharedKey: if present, it bypasses 2FA and browser verification
+   callbacks:
+     needsTwoFactorCode
+     wrongTwoFactorCode
+     authorizationRequired: this is a new browser
+     didFetch: wallet has been downloaded from the server
+     didDecrypt wallet has been decrypted (with the password)
+     didBuildHD: HD part of wallet has been constructed in memory */
 
 MyWallet.login = function (guid, password, credentials, callbacks) {
   assert(credentials.twoFactor !== undefined, '2FA code must be null or set');
@@ -196,7 +195,7 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
   var loginPromise = new Promise(function (resolve, reject) {
     // If the shared key is known, 2FA and browser verification are skipped.
     // No session is needed in that case.
-    if(credentials.sharedKey) {
+    if (credentials.sharedKey) {
       return WalletNetwork.fetchWalletWithSharedKey(guid, credentials.sharedKey)
         .then(function (obj) {
           callbacks.didFetch && callbacks.didFetch();
@@ -216,7 +215,7 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
         // We wait for them to click the link.
         var authorizationRequired = function() {
           var promise = new Promise(function (resolveA, rejectA) {
-            if(typeof(callbacks.authorizationRequired) === 'function') {
+            if (typeof(callbacks.authorizationRequired) === 'function') {
               callbacks.authorizationRequired(function () {
                 WalletNetwork.pollForSessionGUID(token).then(function () {
                   resolveA();
@@ -233,7 +232,7 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
           callbacks.needsTwoFactorCode(token, authType);
         };
 
-        if(credentials.twoFactor) {
+        if (credentials.twoFactor) {
           WalletNetwork.fetchWalletWithTwoFactor(guid, token, credentials.twoFactor)
           .then(function (obj) {
             callbacks.didFetch && callbacks.didFetch();

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -117,7 +117,7 @@ MyWallet.getWallet = function (success, error) {
   });
 };
 
-MyWallet.decryptAndInitializeWallet = function(success, error, decrypt_success, build_hd_success) {
+MyWallet.decryptAndInitializeWallet = function (success, error, decrypt_success, build_hd_success) {
   assert(success, 'Success callback required');
   assert(error, 'Error callback required');
   var encryptedWalletData = WalletStore.getEncryptedWalletData();
@@ -199,8 +199,8 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
       return WalletNetwork.fetchWalletWithSharedKey(guid, credentials.sharedKey)
         .then(function (obj) {
           callbacks.didFetch && callbacks.didFetch();
-          MyWallet.didFetchWallet(obj).then(function() {
-            MyWallet.initializeWallet(password, callbacks.didDecrypt, callbacks.didBuildHD).then(function() {
+          MyWallet.didFetchWallet(obj).then(function () {
+            MyWallet.initializeWallet(password, callbacks.didDecrypt, callbacks.didBuildHD).then(function () {
               resolve({guid: guid});
             }).catch(function (e) {
               reject(e);
@@ -210,16 +210,16 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
     } else {
       // Estabish a session to enable 2FA and browser verification:
       WalletNetwork.establishSession(credentials.sessionToken)
-      .then(function(token) {
+      .then(function (token) {
         // If a new browser is used, the user receives a verification email.
         // We wait for them to click the link.
-        var authorizationRequired = function() {
+        var authorizationRequired = function () {
           var promise = new Promise(function (resolveA, rejectA) {
             if (typeof(callbacks.authorizationRequired) === 'function') {
               callbacks.authorizationRequired(function () {
                 WalletNetwork.pollForSessionGUID(token).then(function () {
                   resolveA();
-                }).catch(function(error) {
+                }).catch(function (error) {
                   rejectA(error);
                 });
               });
@@ -236,8 +236,8 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
           WalletNetwork.fetchWalletWithTwoFactor(guid, token, credentials.twoFactor)
           .then(function (obj) {
             callbacks.didFetch && callbacks.didFetch();
-            MyWallet.didFetchWallet(obj).then(function() {
-              MyWallet.initializeWallet(password, callbacks.didDecrypt, callbacks.didBuildHD).then(function() {
+            MyWallet.didFetchWallet(obj).then(function () {
+              MyWallet.initializeWallet(password, callbacks.didDecrypt, callbacks.didBuildHD).then(function () {
                 resolve({guid: guid, sessionToken: token});
               }).catch(function (e) {
                 reject(e);
@@ -252,8 +252,8 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
           WalletNetwork.fetchWallet(guid, token, needsTwoFactorCode, authorizationRequired)
           .then(function (obj) {
             callbacks.didFetch && callbacks.didFetch();
-            MyWallet.didFetchWallet(obj).then(function() {
-              MyWallet.initializeWallet(password, callbacks.didDecrypt, callbacks.didBuildHD).then(function() {
+            MyWallet.didFetchWallet(obj).then(function () {
+              MyWallet.initializeWallet(password, callbacks.didDecrypt, callbacks.didBuildHD).then(function () {
                 resolve({guid: guid, sessionToken: token});
               }).catch(function (e) {
                 reject(e);
@@ -274,7 +274,7 @@ MyWallet.login = function (guid, password, credentials, callbacks) {
   return loginPromise;
 }
 
-MyWallet.didFetchWallet = function(obj) {
+MyWallet.didFetchWallet = function (obj) {
   if (obj.payload && obj.payload.length > 0 && obj.payload !== 'Not modified') {
    WalletStore.setEncryptedWalletData(obj.payload);
   }
@@ -530,7 +530,7 @@ MyWallet.logout = function (sessionToken, force) {
 
 // In case of a non-mainstream browser, ensure it correctly implements the
 // math needed to derive addresses from a mnemonic.
-MyWallet.browserCheck = function() {
+MyWallet.browserCheck = function () {
   var mnemonic = 'daughter size twenty place alter glass small bid purse october faint beyond';
   var seed = BIP39.mnemonicToSeed(mnemonic, '');
   var masterkey = Bitcoin.HDNode.fromSeedBuffer(seed);
@@ -539,7 +539,7 @@ MyWallet.browserCheck = function() {
   return address === '1QBWUDG4AFL2kFmbqoZ9y4KsSpQoCTZKRw';
 }
 
-MyWallet.browserCheckFast = function() {
+MyWallet.browserCheckFast = function () {
   var seed = Buffer('9f3ad67c5f1eebbffcc8314cb8a3aacbfa28046fd4b3d0af6965a8c804a603e57f5b551320eca4017267550e5b01e622978c133f2085c5999f7ef57a340d0ae2', 'hex');
   var hmacSha512Expected =
     '554d80de8f1747c88d8fb01d27277d0a77ee167886737e91b03da170319858b69ff5840b791b0faaf4b83b54c65886db4ef0f7abc8d0a4e3e10add20681b744f';

--- a/tests/address_spec.js.coffee
+++ b/tests/address_spec.js.coffee
@@ -55,7 +55,7 @@ Helpers = {
 RNG = {
   run: (input) ->
     if RNG.shouldThrow
-      throw 'Connection failed'
+      throw new Error('Connection failed');
     "1111111111111111111111111111111H"
 }
 
@@ -151,7 +151,7 @@ describe "Address", ->
         # This assumes BitcoinJS ECPair.makeRandom does not rescue a throw
         # inside the RNG, which is the case in version 2.1.4
         RNG.shouldThrow = true
-        expect(() -> Address.new("My New Address")).toThrow('Connection failed')
+        expect(() -> Address.new("My New Address")).toThrow(Error('Connection failed'))
 
   describe "instance", ->
     beforeEach ->
@@ -253,15 +253,15 @@ describe "Address", ->
         expect(WalletCrypto.decryptSecretWithSecondPassword).toHaveBeenCalledWith('encpriv', 'secpass', 'shared_key', 5000)
 
       it 'should fail when not passed a bad message', ->
-        expect(a.signMessage.bind(a)).toThrow('Expected message to be a string')
+        expect(a.signMessage.bind(a)).toThrow(Error('Expected message to be a string'))
 
       it 'should fail when encrypted and second pw is not provided', ->
         a._priv = 'encpriv'
-        expect(a.signMessage.bind(a, 'message')).toThrow('Second password needed to decrypt key')
+        expect(a.signMessage.bind(a, 'message')).toThrow(Error('Second password needed to decrypt key'))
 
       it 'should fail when called on a watch only address', ->
         a._priv = null
-        expect(a.signMessage.bind(a, 'message')).toThrow('Private key needed for message signing')
+        expect(a.signMessage.bind(a, 'message')).toThrow(Error('Private key needed for message signing'))
 
       it 'should convert to base64', ->
         spy = jasmine.createSpy('toString')

--- a/tests/blockchain_settings_api_spec.js.coffee
+++ b/tests/blockchain_settings_api_spec.js.coffee
@@ -47,7 +47,7 @@ describe "SettingsAPI", ->
   describe "boolean settings", ->
     booleanSettingsField = [
       {
-        func: "update_IP_lock_on",
+        func: "updateIPlockOn",
         endpoint: "update-ip-lock-on"
       },
       {
@@ -85,14 +85,14 @@ describe "SettingsAPI", ->
 
     describe "TOR block", ->
       it "should work without any callbacks", ->
-        SettingsAPI.update_tor_ip_block(true)
+        SettingsAPI.updateTorIpBlock(true)
 
         # Payload must be 0 or 1, not false or true
         expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 1, payload: '1', method : "update-block-tor-ips" }, jasmine.anything(), jasmine.anything())
         expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-block-tor-ips-success: call succeeded'})
 
       it "should work with callbacks", ->
-        SettingsAPI.update_tor_ip_block(false, observers.success, observers.error)
+        SettingsAPI.updateTorIpBlock(false, observers.success, observers.error)
 
         expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 1, payload: '0', method : "update-block-tor-ips" }, jasmine.anything(), jasmine.anything())
         expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "success", message: 'update-block-tor-ips-success: call succeeded'})
@@ -101,7 +101,7 @@ describe "SettingsAPI", ->
 
       it "should fail if the API call fails", ->
         API.callFailWithoutResponseText = true
-        SettingsAPI.update_tor_ip_block(1, observers.success, observers.error)
+        SettingsAPI.updateTorIpBlock(1, observers.success, observers.error)
 
         expect(API.securePostCallbacks).toHaveBeenCalledWith("wallet", { length: 1, payload: '1', method : 'update-block-tor-ips' }, jasmine.anything(), jasmine.anything())
         expect(WalletStore.sendEvent).toHaveBeenCalledWith("msg", {type: "error", message: 'update-block-tor-ips-error: call failed'})
@@ -111,23 +111,23 @@ describe "SettingsAPI", ->
   describe "string settings", ->
     stringSettingsField = [
       {
-        func: "change_language",
+        func: "changeLanguage",
         endpoint: "update-language"
       },
       {
-        func: "update_IP_lock",
+        func: "updateIPlock",
         endpoint: "update-ip-lock"
       },
       {
-        func: "change_local_currency",
+        func: "changeLocalCurrency",
         endpoint: "update-currency"
       },
       {
-        func: "change_btc_currency",
+        func: "changeBtcCurrency",
         endpoint: "update-btc-currency"
       },
       {
-        func: "change_email",
+        func: "changeEmail",
         endpoint: "update-email"
       },
       {
@@ -208,7 +208,7 @@ describe "SettingsAPI", ->
         errorMessage: 'Error Downloading Activity Logs'
       },
       {
-        func: "get_account_info",
+        func: "getAccountInfo",
         endpoint: "get-info",
         errorMessage: 'Error Downloading Account Settings'
       }
@@ -307,11 +307,11 @@ describe "SettingsAPI", ->
   describe "password hints", ->
     passwordHintFields = [
       {
-        func: "update_password_hint1",
+        func: "updatePasswordHint1",
         endpoint: "update-password-hint1"
       },
       {
-        func: "update_password_hint2",
+        func: "updatePasswordHint2",
         endpoint: "update-password-hint2"
       }
     ]

--- a/tests/blockchain_wallet_spec.js.coffee
+++ b/tests/blockchain_wallet_spec.js.coffee
@@ -128,7 +128,7 @@ describe "Blockchain-Wallet", ->
     RNG = {
       run: (input) ->
         if RNG.shouldThrow
-          throw 'Connection failed'
+          throw new Error('Connection failed');
         "random"
     }
 
@@ -568,7 +568,7 @@ describe "Blockchain-Wallet", ->
           # inside the RNG
           RNG.shouldThrow = true
           wallet.upgradeToV3("ACC-LABEL", null, cb.success, cb.error)
-          expect(cb.error).toHaveBeenCalledWith('Connection failed')
+          expect(cb.error).toHaveBeenCalledWith(Error('Connection failed'))
 
       describe ".newAccount", ->
         cb =

--- a/tests/wallet_crypto_spec.js.coffee
+++ b/tests/wallet_crypto_spec.js.coffee
@@ -155,7 +155,7 @@ describe 'WalletCrypto', ->
           spyOn(observers, "success").and.callThrough()
           spyOn(observers, "error").and.callThrough()
 
-          expect(() -> WalletCrypto.decryptWalletSync(wallet.enc, wallet.password)).toThrow("Wallet version 4 not supported.")
+          expect(() -> WalletCrypto.decryptWalletSync(wallet.enc, wallet.password)).toThrow(Error("Wallet version 4 not supported."))
           WalletCrypto.decryptWallet(wallet.enc, wallet.password, observers.success, observers.error)
           expect(observers.success).not.toHaveBeenCalled()
           expect(observers.error).toHaveBeenCalled()

--- a/tests/wallet_network_spec.js.coffee
+++ b/tests/wallet_network_spec.js.coffee
@@ -26,14 +26,14 @@ describe "WalletNetwork", ->
               resolve({success: false, message: "Invalid Captcha"})
         else if method == "wallet/1234"
           if API.callFail
-            throw ''
+            throw '';
           else
             resolve('done')
         else if method == "wallet/poll-for-session-guid"
           resolve({guid: "1234"})
         else if action == "POST" && method == "sessions"
           if API.callFail
-            throw ''
+            throw '';
           else
             resolve({token: 'token'})
         else if method == "kaptcha.jpg"
@@ -65,7 +65,7 @@ describe "WalletNetwork", ->
         ['encrypted']
     decryptWalletSync: () ->
       if WalletCrypto.decryptError
-        throw ''
+        throw Error('');
       else
         'decrypted'
     sha256: (msg) -> msg

--- a/tests/wallet_spec.js.coffee
+++ b/tests/wallet_spec.js.coffee
@@ -107,7 +107,7 @@ BIP39 = {
 RNG = {
   run: (input) ->
     if RNG.shouldThrow
-      throw 'Connection failed'
+      throw new Error('Connection failed');
     "random"
 }
 
@@ -489,7 +489,7 @@ describe "Wallet", ->
       # This assumes BIP39.generateMnemonic does not rescue a throw
       # inside the RNG
       RNG.shouldThrow = true
-      expect(() -> MyWallet.createNewWallet()).toThrow('Connection failed')
+      expect(() -> MyWallet.createNewWallet()).toThrow(Error('Connection failed'))
       RNG.shouldThrow = false
 
     describe "when the wallet insertion fails", ->


### PR DESCRIPTION
New minor release needed. Frontend & iOs should change (cc @woudini):
- error handling when importing a legacy address: `presentInWallet`; check `e.message` instead of just `e`
- blockchain-settings-api: `get_account_info` -> `getAccountInfo`
- `update_IP_lock` -> `updateIPlock`
- `update_IP_lock_on` -> `updateIPlockOn`
- `change_language` -> `changeLanguage`
- `change_btc_currency` -> `changeBtcCurrency`
- `change_local_currency` -> `changeLocalCurrency`
- `update_tor_ip_block` -> `updateTorIpBlock`
- `update_password_hint1` -> `updatePasswordHint1`
- `update_password_hint2` -> `updatePasswordHint2`
- `change_email` -> `changeEmail`

Most important changes:
- replaced `throw 'Error: the error'` with `throw new Error('the error')`
 - most of these throws won't be triggered by the frontend because it already validates input
 - one exception is `presentInWallet`; the frontend needs to call `e.message` instead of just `e`.
- eqeqeq: I manually went through those
 - most `==` were safe to replace with `===` 
 - I added `| a === null` wherever I saw `a == undefined` (which was not very often)
 - no tests broke
- camel case method names
 