### PR TITLE
fix(Wallet): show timeout error with bad internet connection

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -486,9 +486,12 @@ MyWallet.createNewWallet = function (inputedEmail, inputedPassword, firstAccount
     });
   };
 
-  var mnemonic = BIP39.generateMnemonic(undefined, RNG.run.bind(RNG));
-
-  WalletSignup.generateNewWallet(inputedPassword, inputedEmail, mnemonic, undefined, firstAccountName, saveWallet, errorCallback);
+  try {
+    var mnemonic = BIP39.generateMnemonic(undefined, RNG.run.bind(RNG));
+    WalletSignup.generateNewWallet(inputedPassword, inputedEmail, mnemonic, undefined, firstAccountName, saveWallet, errorCallback);
+  } catch(e) {
+    errorCallback(e);
+  }
 };
 
 // used on frontend

--- a/tests/wallet_spec.js.coffee
+++ b/tests/wallet_spec.js.coffee
@@ -484,12 +484,22 @@ describe "Wallet", ->
       expect(BIP39.generateMnemonic).toHaveBeenCalled()
       expect(RNG.run).toHaveBeenCalled()
 
-    it "should throw if RNG throws", ->
+    it "should call errorCallback if RNG throws", ->
       # E.g. because there was a network failure.
       # This assumes BIP39.generateMnemonic does not rescue a throw
       # inside the RNG
-      RNG.shouldThrow = true
-      expect(() -> MyWallet.createNewWallet()).toThrow('Connection failed')
+
+      observers = null
+
+      beforeEach (done) ->
+        observers =
+          error: () -> done()
+
+        spyOn(observers, "error").and.callThrough()
+
+        RNG.shouldThrow = true
+        MyWallet.createNewWallet('a@b.com', "1234", 'My Wallet', 'en', 'usd', observers.success, observers.error)
+        expect(observers.error).toHaveBeenCalledWith('Connection failed')
       RNG.shouldThrow = false
 
     describe "when the wallet insertion fails", ->


### PR DESCRIPTION
This will allow showing a message on the `errorCallback` for a very frequent crash currently seen on iOS (2.3.0 b15) due to the `RNG.prototype.getServerEntropy` timing out:

`Javscript Exception: Error generating the entropyError: TimeoutError: DOM Exception 23`