### PR TITLE
Store get-info result in AccountInfo

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -83,7 +83,8 @@ module.exports = function (config) {
       'tests/transaction_list_spec.js.coffee',
       'tests/wallet_crypto_spec.js.coffee',
       'tests/wallet_signup_spec.js.coffee',
-      'tests/blockchain_settings_api_spec.js.coffee'
+      'tests/blockchain_settings_api_spec.js.coffee',
+      'tests/account_info_spec.js.coffee'
     ]
   };
 

--- a/src/account-info.js
+++ b/src/account-info.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = AccountInfo;
+
+function AccountInfo (object) {
+  this._email = object.email;
+
+  if (object.sms_number.length > 5) {
+    this._mobile = {
+      countryCode: object.sms_number.split(' ')[0].substr(1),
+      number: object.sms_number.split(' ')[1]
+    };
+  } else {
+    this._mobile = null;
+  }
+
+  this._dialCode = object.dial_code;
+
+  this._isEmailVerified = Boolean(object.email_verified);
+  this._isMobileVerified = Boolean(object.sms_verified);
+
+  this._currency = object.currency;
+}
+
+Object.defineProperties(AccountInfo.prototype, {
+
+  'email': {
+    configurable: false,
+    get: function () { return this._email; }
+  },
+  'mobileObject': {
+    configurable: false,
+    get: function () { return this._mobile; }
+  },
+  'mobile': {
+    configurable: false,
+    get: function () {
+      return '+' + this._mobile.countryCode + this._mobile.number.replace(/^0*/, '');
+    }
+  },
+  'dialCode': {
+    configurable: false,
+    get: function () { return this._dialCode; }
+  },
+  'isEmailVerified': {
+    configurable: false,
+    get: function () { return this._isEmailVerified; }
+  },
+  'isMobileVerified': {
+    configurable: false,
+    get: function () { return this._isMobileVerified; }
+  },
+  'currency': {
+    configurable: false,
+    get: function () { return this._currency; }
+  }
+});

--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -6,6 +6,15 @@ var WalletStore = require('./wallet-store.js');
 var MyWallet = require('./wallet.js');
 var API = require('./api');
 
+function fetchAccountInfo () {
+  return API.securePost('wallet', {method: 'get-info', format: 'json'})
+    .catch(function (data) {
+      var response = data.responseText || 'Error Downloading Account Settings';
+      WalletStore.sendEvent('msg', {type: 'error', message: response});
+    });
+}
+
+// TODO: depricate
 function getAccountInfo (success, error) {
   API.securePostCallbacks('wallet', {method: 'get-info', format: 'json'}, function (data) {
     typeof (success) === 'function' && success(data);
@@ -276,6 +285,7 @@ function disableAllNotifications (success, error) {
 }
 
 module.exports = {
+  fetchAccountInfo: fetchAccountInfo,
   getAccountInfo: getAccountInfo,
   updateIPlock: updateIPlock,
   updateIPlockOn: updateIPlockOn,

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -19,6 +19,7 @@ var BlockchainSettingsAPI = require('./blockchain-settings-api');
 var KeyRing = require('./keyring');
 var TxList = require('./transaction-list');
 var Block = require('./bitcoin-block');
+var AccountInfo = require('./account-info');
 
 // Wallet
 
@@ -70,6 +71,7 @@ function Wallet (object) {
   this._numberTxTotal = 0;
   this._txList = new TxList();
   this._latestBlock = null;
+  this._accountInfo = null;
 }
 
 Object.defineProperties(Wallet.prototype, {
@@ -303,6 +305,10 @@ Object.defineProperties(Wallet.prototype, {
         throw new Error('wallet.logoutTime must be a positive integer in range 60000,86400001');
       }
     }
+  },
+  'accountInfo': {
+    configurable: false,
+    get: function () { return this._accountInfo; }
   }
 });
 
@@ -793,4 +799,12 @@ Wallet.prototype._getPrivateKey = function (accountIndex, path, secondPassword) 
       : maybeXpriv;
   var kr = new KeyRing(xpriv, null);
   return kr.privateKeyFromPath(path).keyPair.toWIF();
+};
+
+Wallet.prototype.fetchAccountInfo = function () {
+  var parentThis = this;
+  return BlockchainSettingsAPI.fetchAccountInfo().then(function (info) {
+    parentThis._accountInfo = new AccountInfo(info);
+    return info; // TODO: handle more here instead of in the frontend / iOs
+  });
 };

--- a/tests/account_info_spec.js.coffee
+++ b/tests/account_info_spec.js.coffee
@@ -1,0 +1,77 @@
+proxyquire = require('proxyquireify')(require)
+
+stubs = { }
+AccountInfo = proxyquire('../src/account-info', stubs)
+
+
+describe "AccountInfo", ->
+
+  beforeEach ->
+
+  describe "parse get-info", ->
+    # Typical result from get-info:
+    o =
+      btc_currency: "BTC"
+      notifications_type: []
+      language: "nl"
+      notifications_on: 2,
+      ip_lock_on:0,
+      dial_code:"420"
+      block_tor_ips:0,
+      currency:"EUR"
+      notifications_confirmations:0
+      auto_email_backup:0
+      never_save_auth_type:0
+      email: "support@blockchain.info"
+      sms_verified:1
+      is_api_access_enabled:0,
+      auth_type:0
+      my_ip: "188.175.127.229"
+      email_verified:0
+      languages:
+        de:"German"
+        no:"Norwegian"
+        en:"English"
+      country_code:"CZ"
+      logging_level:0
+      guid:"1234"
+      ip_lock:"192.168.0.1",
+      btc_currencies:
+        BTC:"Bitcoin",
+        UBC:"Bits (uBTC)"
+        MBC:"MilliBit (mBTC)"
+      sms_number:"+1 055512345"
+      currencies:
+        ISK: "Icelandic Króna"
+        HKD: "Hong Kong Dollar"
+        EUR: "Euro"
+        DKK: "Danish Krone"
+        USD: "U.S. dollar"
+
+    it "should get email", ->
+      i = new AccountInfo(o)
+      expect(i.email).toEqual("support@blockchain.info")
+
+    it "should remove space and leading zero from mobile", ->
+      i = new AccountInfo(o)
+      expect(i.mobile).toEqual("+155512345")
+
+    it "should split mobile into object with country and number", ->
+      i = new AccountInfo(o)
+      expect(i.mobileObject).toEqual({countryCode: "1", number: "055512345"})
+
+    it "should get email verification status", ->
+      i = new AccountInfo(o)
+      expect(i.isEmailVerified).toEqual(false)
+
+    it "should get mobile verification status", ->
+      i = new AccountInfo(o)
+      expect(i.isMobileVerified).toEqual(true)
+
+    it "should get the current country's dial code", ->
+      i = new AccountInfo(o)
+      expect(i.dialCode).toEqual("420")
+
+    it "should get the users currency", ->
+      i = new AccountInfo(o)
+      expect(i.currency).toEqual("EUR")


### PR DESCRIPTION
The frontend now calls `MyWallet.wallet.fetchAccountInfo().then((result) => { ... }` instead of `BlockchainSettingsAPI.getAccountInfo((res) => { ... })`. 

The users mobile number, email, verification status and currency are stored in `AccountInfo`. They can be retrieved by calling `AccountInfo.email`, etc. We can add more settings to this in the future.

@woudini `getAccountInfo` will continue to work as before. It will be depreciated at some point, so I suggest you switch to the `fetchAccountInfo()` promise. This passes the `result` object in the same way, so you don't have to change anything else.