### PR TITLE
Use new /balance endpoint

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -122,7 +122,6 @@ API.prototype.handleNTPResponse = function (obj, clientTime) {
 API.prototype.getBalances = function (addresses) {
   var data = {
     active: addresses.join('|'),
-    simple: true,
     format: 'json',
     api_code: this.API_CODE
   };

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -598,27 +598,22 @@ Wallet.reviver = function (k, v) {
 
 function isAccountNonUsed (account, progress) {
   var isNonUsed = function (obj) {
-    if (progress) { progress(obj); }
-    return obj.addresses[0].account_index === 0 && obj.addresses[0].change_index === 0;
+    var result = obj[account.extendedPublicKey];
+    progress && progress(result);
+    return result.total_received === 0;
   };
   return API.getBalances([account.extendedPublicKey]).then(isNonUsed);
 }
 
-Wallet.prototype.scanBip44 = function (secondPassword, startedRestoreHDWallet, progress) {
-  // wallet restoration
-  startedRestoreHDWallet && startedRestoreHDWallet();
+Wallet.prototype.scanBip44 = function (secondPassword, progress) {
   var self = this;
-  API.getBalances([self.hdwallet._accounts[0].extendedPublicKey]).then(progress);
   var accountIndex = 1;
   var AccountsGap = 10;
+  isAccountNonUsed(self.hdwallet._accounts[0], progress);
 
   var untilNEmptyAccounts = function (n) {
     var go = function (nonused) {
-      if (nonused) {
-        return untilNEmptyAccounts(n - 1);
-      } else {
-        return untilNEmptyAccounts(AccountsGap);
-      }
+      return untilNEmptyAccounts(nonused ? n - 1 : AccountsGap);
     };
     if (n === 0) {
       self.hdwallet._accounts.splice(-AccountsGap);
@@ -630,7 +625,6 @@ Wallet.prototype.scanBip44 = function (secondPassword, startedRestoreHDWallet, p
     }
   };
 
-  // it returns a promise of the new HDWallet
   return untilNEmptyAccounts(AccountsGap);
 };
 

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -542,7 +542,8 @@ MyWallet.recoverFromMnemonic = function (inputedEmail, inputedPassword, mnemonic
     };
 
     WalletStore.unsafeSetPassword(inputedPassword);
-    wallet.scanBip44(undefined, startedRestoreHDWallet, accountProgress).then(saveWallet).catch(error);
+    startedRestoreHDWallet && startedRestoreHDWallet();
+    wallet.scanBip44(undefined, accountProgress).then(saveWallet).catch(error);
   };
 
   WalletSignup.generateNewWallet(inputedPassword, inputedEmail, mnemonic, bip39Password, null, walletGenerated, error, generateUUIDProgress, decryptWalletProgress);


### PR DESCRIPTION
This change is for compatibility with the /balance response.

@woudini, the object passed to the `accountProgress` callback of `MyWallet.recoverFromMnemonic` was changed. It looks like this now:

```
{
  total_available: Number,
  final_balance: Number,
  total_sent: Number,
  n_tx: Number
}
```

So [this](https://github.com/blockchain/My-Wallet-V3-iOS/blob/master/Blockchain/js/wallet-ios.js#L1579) will need to be updated.