### PR TITLE
Set syncPubKeys when updating notification settings

### DIFF
--- a/src/blockchain-settings-api.js
+++ b/src/blockchain-settings-api.js
@@ -281,11 +281,17 @@ function updateNotificationsType (types) {
     return acc | n;
   });
 
+  var success = function (result) {
+    WalletStore.setSyncPubKeys(payload !== 0);
+    MyWallet.syncWallet();
+    return result;
+  };
+
   return API.securePost('wallet', {
     method: 'update-notifications-type',
     length: String(payload).length,
     payload: payload
-  });
+  }).then(success);
 }
 
 function updateNotificationsOn (on) {

--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -633,33 +633,13 @@ Wallet.prototype.scanBip44 = function (secondPassword, progress) {
 Wallet.prototype.enableNotifications = function (success, error) {
   assert(success, 'Success callback required');
   assert(error, 'Error callback required');
-
-  BlockchainSettingsAPI.enableEmailReceiveNotifications(
-    function () {
-      WalletStore.setSyncPubKeys(true);
-      MyWallet.syncWallet();
-      success();
-    },
-    function () {
-      error();
-    }
-  );
+  BlockchainSettingsAPI.enableEmailReceiveNotifications(success, error);
 };
 
 Wallet.prototype.disableNotifications = function (success, error) {
   assert(success, 'Success callback required');
   assert(error, 'Error callback required');
-
-  BlockchainSettingsAPI.disableAllNotifications(
-    function () {
-      WalletStore.setSyncPubKeys(false);
-      MyWallet.syncWallet();
-      success();
-    },
-    function () {
-      error();
-    }
-  );
+  BlockchainSettingsAPI.disableAllNotifications(success, error);
 };
 
 // creating a new wallet object

--- a/tests/blockchain_wallet_spec.js.coffee
+++ b/tests/blockchain_wallet_spec.js.coffee
@@ -768,39 +768,9 @@ describe "Blockchain-Wallet", ->
           expect(() -> wallet.enableNotifications(cb.success)).toThrow()
           expect(() -> wallet.enableNotifications(cb.success, cb.error)).not.toThrow()
 
-        it "should call setSyncPubKeys and syncWallet if successful", ->
-          wallet.enableNotifications(cb.success, cb.error)
-          expect(MyWallet.syncWallet).toHaveBeenCalled()
-          expect(WalletStore.setSyncPubKeys).toHaveBeenCalledWith(true)
-          expect(cb.success).toHaveBeenCalled()
-          expect(cb.error).not.toHaveBeenCalled()
-
-        it "should not call setSyncPubKeys and syncWallet if successful", ->
-          BlockchainSettingsAPI.shouldFail = true
-          wallet.enableNotifications(cb.success, cb.error)
-          expect(MyWallet.syncWallet).not.toHaveBeenCalled()
-          expect(WalletStore.setSyncPubKeys).not.toHaveBeenCalled()
-          expect(cb.success).not.toHaveBeenCalled()
-          expect(cb.error).toHaveBeenCalled()
-
       describe ".disableNotifications", ->
 
         it "should require success and error callbacks", ->
           expect(() -> wallet.disableNotifications()).toThrow()
           expect(() -> wallet.disableNotifications(cb.success)).toThrow()
           expect(() -> wallet.disableNotifications(cb.success, cb.error)).not.toThrow()
-
-        it "should call setSyncPubKeys and syncWallet if successful", ->
-          wallet.disableNotifications(cb.success, cb.error)
-          expect(MyWallet.syncWallet).toHaveBeenCalled()
-          expect(WalletStore.setSyncPubKeys).toHaveBeenCalledWith(false)
-          expect(cb.success).toHaveBeenCalled()
-          expect(cb.error).not.toHaveBeenCalled()
-
-        it "should not call setSyncPubKeys and syncWallet if successful", ->
-          BlockchainSettingsAPI.shouldFail = true
-          wallet.disableNotifications(cb.success, cb.error)
-          expect(MyWallet.syncWallet).not.toHaveBeenCalled()
-          expect(WalletStore.setSyncPubKeys).not.toHaveBeenCalled()
-          expect(cb.success).not.toHaveBeenCalled()
-          expect(cb.error).toHaveBeenCalled()


### PR DESCRIPTION
Before, updateNotificationsType wasn't setting syncPubKeys, which would mean on the next wallet sync the server would not get told which addresses to watch for notifications.