### PR TITLE
Optional api_code parameter

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -32,6 +32,9 @@ API.prototype.encodeFormData = function (data) {
 /* Permitted extra headers:
    sessionToken -> "Authorization Bearer <token>" */
 API.prototype.request = function (action, method, data, extraHeaders) {
+  data = data || {};
+  if (this.API_CODE != null) data.api_code = this.API_CODE;
+
   var url = this.ROOT_URL + method;
   var body = data ? this.encodeFormData(data) : '';
   var time = (new Date()).getTime();
@@ -122,8 +125,7 @@ API.prototype.handleNTPResponse = function (obj, clientTime) {
 API.prototype.getBalances = function (addresses) {
   var data = {
     active: addresses.join('|'),
-    format: 'json',
-    api_code: this.API_CODE
+    format: 'json'
   };
   return this.retry(this.request.bind(this, 'POST', 'balance', data));
 };
@@ -132,8 +134,7 @@ API.prototype.getTransaction = function (txhash) {
   var transaction = 'tx/' + txhash;
   var data = {
     format: 'json',
-    cors: 'true',
-    api_code: this.API_CODE
+    cors: 'true'
   };
   return this.retry(this.request.bind(this, 'GET', transaction, data));
 };
@@ -158,14 +159,13 @@ API.prototype.getFiatAtTime = function (time, value, currencyCode) {
     currency: currencyCode,
     time: time,
     textual: false,
-    nosavecurrency: true,
-    api_code: this.API_CODE
+    nosavecurrency: true
   };
   return this.retry(this.request.bind(this, 'GET', 'frombtc', data));
 };
 
 API.prototype.getTicker = function () {
-  var data = { format: 'json', api_code: this.API_CODE };
+  var data = { format: 'json' };
   // return this.request('GET', 'ticker', data);
   return this.retry(this.request.bind(this, 'GET', 'ticker', data));
 };
@@ -174,8 +174,7 @@ API.prototype.getUnspent = function (fromAddresses, confirmations) {
   var data = {
     active: fromAddresses.join('|'),
     confirmations: Helpers.isPositiveNumber(confirmations) ? confirmations : -1,
-    format: 'json',
-    api_code: this.API_CODE
+    format: 'json'
   };
   return this.retry(this.request.bind(this, 'POST', 'unspent', data));
 };
@@ -193,8 +192,7 @@ API.prototype.getHistory = function (addresses, txFilter, offset, n, syncBool) {
     ct: clientTime,
     n: n,
     language: WalletStore.getLanguage(),
-    no_buttons: true,
-    api_code: this.API_CODE
+    no_buttons: true
   };
 
   if (txFilter !== undefined && txFilter !== null) {
@@ -228,7 +226,6 @@ API.prototype.securePost = function (url, data, extraHeaders) {
     clone.sKDebugOriginalClientTime = now;
     clone.sKDebugOriginalSharedKey = sharedKey;
   }
-  clone.api_code = this.API_CODE;
   clone.format = data.format ? data.format : 'plain';
 
   return this.retry(this.request.bind(this, 'POST', url, clone, extraHeaders));
@@ -244,7 +241,6 @@ API.prototype.pushTx = function (txHex, note) {
 
   var data = {
     tx: txHex,
-    api_code: this.API_CODE,
     format: 'plain'
   };
 

--- a/src/wallet-network.js
+++ b/src/wallet-network.js
@@ -28,8 +28,7 @@ function handleResponse (obj) {
 function generateUUIDs (count) {
   var data = {
     format: 'json',
-    n: count,
-    api_code: API.API_CODE
+    n: count
   };
 
   var extractUUIDs = function (data) {
@@ -56,8 +55,7 @@ function resendTwoFactorSms (userGuid, sessionToken) {
   var data = {
     format: 'json',
     resend_code: true,
-    ct: Date.now(),
-    api_code: API.API_CODE
+    ct: Date.now()
   };
 
   var headers = {sessionToken: sessionToken};
@@ -77,8 +75,7 @@ function recoverGuid (sessionToken, userEmail, captcha) {
     method: 'recover-wallet',
     email: userEmail,
     captcha: captcha,
-    ct: Date.now(),
-    api_code: API.API_CODE
+    ct: Date.now()
   };
 
   var headers = {
@@ -128,8 +125,7 @@ function requestTwoFactorReset (
     secret_phrase: secret,
     message: message,
     kaptcha: captcha,
-    ct: Date.now(),
-    api_code: API.API_CODE
+    ct: Date.now()
   };
 
   var headers = {
@@ -217,7 +213,7 @@ function establishSession (token) {
 // token must be present if sharedKey isn't
 function callGetWalletEndpoint (guid, sharedKey, sessionToken) {
   var clientTime = (new Date()).getTime();
-  var data = { format: 'json', resend_code: null, ct: clientTime, api_code: API.API_CODE };
+  var data = { format: 'json', resend_code: null, ct: clientTime };
   var headers = {};
 
   if (sharedKey) {
@@ -304,8 +300,7 @@ function fetchWalletWithTwoFactor (guid, sessionToken, twoFactor) {
       payload: twoFactorAuthKey,
       length: twoFactorAuthKey.length,
       method: 'get-wallet',
-      format: 'plain',
-      api_code: API.API_CODE
+      format: 'plain'
     };
 
     var headers = {sessionToken: sessionToken};

--- a/src/wallet-token-endpoints.js
+++ b/src/wallet-token-endpoints.js
@@ -19,8 +19,7 @@ function postTokenEndpoint (method, token, extraParams) {
 
   var params = {
     token: token,
-    method: method,
-    api_code: API.API_CODE
+    method: method
   };
 
   for (var k in extraParams) {

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -558,7 +558,7 @@ MyWallet.logout = function (sessionToken, force) {
       console.log(e);
     }
   };
-  var data = {format: 'plain', api_code: API.API_CODE};
+  var data = { format: 'plain' };
   WalletStore.sendEvent('logging_out');
 
   var headers = {sessionToken: sessionToken};


### PR DESCRIPTION
Setting `API.API_CODE` to `undefined` or `null` will send that value to the server, causing an error. This change makes it so that it won't be sent, giving the option to make requests without an api code (needed for service-my-wallet).