### PR TITLE
feat(WalletTransaction): compute To and From

### DIFF
--- a/src/wallet-transaction.js
+++ b/src/wallet-transaction.js
@@ -292,7 +292,9 @@ Tx.IOSfactory = function (tx) {
     fromWatchOnly: tx.fromWatchOnly,
     toWatchOnly: tx.toWatchOnly,
     to: tx.to,
-    from: tx.from
+    from: tx.from,
+    fee: tx.fee,
+    note: tx.note
   };
 };
 

--- a/tests/wallet_transaction_spec.js.coffee
+++ b/tests/wallet_transaction_spec.js.coffee
@@ -10,6 +10,7 @@ MyWallet =
 
     key: () -> { label: "Genesis", isWatchOnly: true }
     latestBlock: { height: 399680 }
+    getAddressBookLabel: (address) -> "addressBookLabel"
 
 transactions = require('./data/transactions')
 
@@ -36,7 +37,8 @@ describe 'Transaction', ->
       expect(tx.toWatchOnly).toBeFalsy()
       expect(tx.txType).toEqual("sent")
       expect(tx.amount).toEqual(-30000)
-
+      expect(tx.from.address).toEqual("1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa")
+      expect(tx.to[0].address).toEqual("1M5hoG1pCTDsPqZwG6WH25ziwYYaXNMLrU")
 
     it "should have a fee equal to the difference between inputs and outputs value", ->
       tx = Tx.factory(transactions["default"])
@@ -105,7 +107,12 @@ describe 'Transaction', ->
       ios = Tx.IOSfactory(tx)
       expect(ios.time).toEqual(tx.time)
       expect(ios.result).toEqual(tx.result)
+      expect(ios.amount).toEqual(tx.amount)
       expect(ios.confirmations).toEqual(tx.confirmations)
+      expect(ios.myHash).toEqual(tx.hash)
       expect(ios.txType).toEqual(tx.txType)
       expect(ios.block_height).toEqual(tx.block_height)
-      expect(ios.myHash).toEqual(tx.hash)
+      expect(ios.fromWatchOnly).toEqual(tx.fromWatchOnly)
+      expect(ios.toWatchOnly).toEqual(tx.toWatchOnly)
+      expect(ios.to).toEqual(tx.to)
+      expect(ios.from).toEqual(tx.from)


### PR DESCRIPTION
Web and iOS both need the To and From for each transaction - no need to do this twice.

`formatTransactionCoins()` should be identical to this:
https://github.com/blockchain/My-Wallet-V3-Frontend/blob/4ec80c7a883c108b4de64c5cc27fac7c498efeec/assets/js/services/wallet.service.js#L747

`computeTo()` should be identical to this:
https://github.com/blockchain/My-Wallet-V3-Frontend/blob/646837adebe5f24bca02f56aa5e7e26b5c856bd8/assets/js/directives/transaction-destinations.directive.js#L27

This line https://github.com/blockchain/My-Wallet-V3/pull/260/files#diff-6633aab2a44df5fd20394084f8a0695eR262 was required to pass the test here https://github.com/blockchain/My-Wallet-V3/blob/d2e756ac1d700a1bf4a574b85f7c95492ccb9bd4/tests/wallet_transaction_spec.js.coffee#L24