### PR TITLE
Detect meta data service failure

### DIFF
--- a/src/buy-sell.js
+++ b/src/buy-sell.js
@@ -8,15 +8,31 @@ function BuySell (wallet) {
   // Stop if 2nd password is enabled
   if (wallet.external === null) return;
 
+  // Stop if meta data failed to load;
+  if (!wallet.external.success) {
+    return;
+  }
+
   // Add Coinify if not already added:
   if (!this._wallet.external.coinify) this._wallet.external.addCoinify();
 }
 
 Object.defineProperties(BuySell.prototype, {
+  'status': {
+    configurable: false,
+    get: function () {
+      return {
+        metaDataService: this._wallet.external.success
+      };
+    }
+  },
   'exchanges': {
     configurable: false,
     get: function () {
-      if (this._wallet.external === null) return;
+      if (
+        this._wallet.external === null ||
+        !this._wallet.external.success
+      ) return;
       return {
         coinify: this._wallet.external.coinify
       };

--- a/src/external.js
+++ b/src/external.js
@@ -31,6 +31,7 @@ External.prototype.toJSON = function () {
 
 External.prototype.fetchOrCreate = function () {
   var createOrPopulate = function (object) {
+    this.success = true;
     if (object === null) { // entry non exitent
       return this._metadata.create(this);
     } else {
@@ -38,7 +39,11 @@ External.prototype.fetchOrCreate = function () {
       return this;
     }
   };
-  return this._metadata.fetch().then(createOrPopulate.bind(this));
+  var fetchFailed = function (e) {
+    // Metadata service is down or unreachable.
+    this.success = false;
+  };
+  return this._metadata.fetch().then(createOrPopulate.bind(this)).catch(fetchFailed.bind(this));
 };
 
 External.prototype.save = function () {

--- a/src/external.js
+++ b/src/external.js
@@ -42,6 +42,7 @@ External.prototype.fetchOrCreate = function () {
   var fetchFailed = function (e) {
     // Metadata service is down or unreachable.
     this.success = false;
+    return Promise.reject(e);
   };
   return this._metadata.fetch().then(createOrPopulate.bind(this)).catch(fetchFailed.bind(this));
 };

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -79,6 +79,7 @@ Metadata.prototype.create = function (data) {
 
 Metadata.prototype.fetch = function () {
   var self = this;
+
   return this.GET(this._address).then(function (serverPayload) {
     if (serverPayload === null) {
       return null;
@@ -100,6 +101,9 @@ Metadata.prototype.fetch = function () {
     } else {
       throw new Error('METADATA_SIGNATURE_VERIFICATION_ERROR');
     }
+  }).catch(function (e) {
+    console.log(e);
+    throw new Error('METADATA_FETCH_FAILED');
   });
 };
 
@@ -136,6 +140,9 @@ Metadata.prototype.update = function (data) {
 };
 
 Metadata.prototype.GET = function (endpoint, data) {
+  // if (this._payloadTypeId === 3) {
+  //   return Promise.reject('DEBUG: simulate meta data service failure');
+  // }
   return this.request('GET', endpoint, data);
 };
 

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -103,7 +103,7 @@ Metadata.prototype.fetch = function () {
     }
   }).catch(function (e) {
     console.log(e);
-    throw new Error('METADATA_FETCH_FAILED');
+    return Promise.reject('METADATA_FETCH_FAILED');
   });
 };
 


### PR DESCRIPTION
If the meta data service fails to fetch, external will have `status.metaDataService` set to `false`. When a fetch fails e.g. due to a network or server problem, we don't know if the user has a metadata entry or not. This is different from a 404 response, where we know for sure the user doesn't have an entry.