### PR TITLE
Handle login at Coinify level

### DIFF
--- a/src/coinify/coinify.js
+++ b/src/coinify/coinify.js
@@ -267,15 +267,7 @@ Coinify.prototype.buy = function (amount, baseCurrency, medium) {
 
   var self = this;
 
-  var doBuy = function () {
-    return CoinifyTrade.buy(self._lastQuote, medium, self);
-  };
-
-  if (!this.isLoggedIn) {
-    return this.login().then(doBuy);
-  } else {
-    return doBuy();
-  }
+  return CoinifyTrade.buy(self._lastQuote, medium, self);
 };
 
 Coinify.prototype.getTrades = function () {
@@ -285,15 +277,7 @@ Coinify.prototype.getTrades = function () {
 Coinify.prototype.triggerKYC = function () {
   var self = this;
 
-  var doKYC = function () {
-    return CoinifyKYC.trigger(self);
-  };
-
-  if (!this.isLoggedIn) {
-    return this.login().then(doKYC);
-  } else {
-    return doKYC();
-  }
+  return CoinifyKYC.trigger(self);
 };
 
 Coinify.prototype.getKYCs = function () {

--- a/src/coinify/coinify.js
+++ b/src/coinify/coinify.js
@@ -126,6 +126,12 @@ Object.defineProperties(Coinify.prototype, {
       return this._payment_methods;
     }
   },
+  'hasAccount': {
+    configurable: false,
+    get: function () {
+      return Boolean(this._offline_token);
+    }
+  },
   'isLoggedIn': {
     configurable: false,
     get: function () {
@@ -234,15 +240,7 @@ Coinify.prototype.login = function () {
 };
 
 Coinify.prototype.fetchProfile = function () {
-  var parentThis = this;
-
-  if (this.isLoggedIn) {
-    return this._profile.fetch();
-  } else {
-    return this.login().then(function () {
-      return parentThis._profile.fetch();
-    });
-  }
+  return this._profile.fetch();
 };
 
 Coinify.prototype.getBuyQuote = function (amount, baseCurrency, quoteCurrency) {
@@ -358,12 +356,48 @@ Coinify.prototype.GET = function (endpoint, data) {
   return this.request('GET', endpoint, data);
 };
 
+Coinify.prototype.authGET = function (endpoint, data) {
+  var doGET = function () {
+    return this.GET(endpoint, data);
+  };
+
+  if (this.isLoggedIn) {
+    return doGET.bind(this)();
+  } else {
+    return this.login().then(doGET.bind(this));
+  }
+};
+
 Coinify.prototype.POST = function (endpoint, data) {
   return this.request('POST', endpoint, data);
 };
 
+Coinify.prototype.authPOST = function (endpoint, data) {
+  var doPOST = function () {
+    return this.POST(endpoint, data);
+  };
+
+  if (this.isLoggedIn) {
+    return doPOST.bind(this)();
+  } else {
+    return this.login().then(doPOST.bind(this));
+  }
+};
+
 Coinify.prototype.PATCH = function (endpoint, data) {
   return this.request('PATCH', endpoint, data);
+};
+
+Coinify.prototype.authPATCH = function (endpoint, data) {
+  var doPATCH = function () {
+    return this.PATCH(endpoint, data);
+  };
+
+  if (this.isLoggedIn) {
+    return doPATCH.bind(this)();
+  } else {
+    return this.login().then(doPATCH.bind(this));
+  }
 };
 
 Coinify.prototype.request = function (method, endpoint, data) {

--- a/src/coinify/kyc.js
+++ b/src/coinify/kyc.js
@@ -49,14 +49,7 @@ Object.defineProperties(CoinifyKYC.prototype, {
 });
 
 CoinifyKYC.prototype.refresh = function () {
-  var updateTrade = function () {
-    return this._coinify.GET('kyc/' + this._id).then(this.set.bind(this));
-  };
-  if (this._coinify.isLoggedIn) {
-    return updateTrade.bind(this)();
-  } else {
-    return this._coinify.login().then(updateTrade.bind(this));
-  }
+  return this._coinify.authGET('kyc/' + this._id).then(this.set.bind(this));
 };
 
 CoinifyKYC.trigger = function (coinify) {
@@ -66,26 +59,18 @@ CoinifyKYC.trigger = function (coinify) {
     return kyc;
   };
 
-  return coinify.POST('traders/me/kyc').then(processKYC);
+  return coinify.authPOST('traders/me/kyc').then(processKYC);
 };
 
 // Fetches the latest trades and updates coinify._trades
 CoinifyKYC.fetchAll = function (coinify) {
-  var getKycs = function () {
-    return coinify.GET('kyc').then(function (res) {
-      coinify._kycs.length = 0; // empty array without losing reference
-      for (var i = 0; i < res.length; i++) {
-        var kyc = new CoinifyKYC(res[i], coinify);
-        coinify._kycs.push(kyc);
-      }
+  return coinify.authGET('kyc').then(function (res) {
+    coinify._kycs.length = 0; // empty array without losing reference
+    for (var i = 0; i < res.length; i++) {
+      var kyc = new CoinifyKYC(res[i], coinify);
+      coinify._kycs.push(kyc);
+    }
 
-      return coinify._kycs;
-    });
-  };
-
-  if (coinify.isLoggedIn) {
-    return getKycs();
-  } else {
-    return coinify.login().then(getKycs);
-  }
+    return coinify._kycs;
+  });
 };

--- a/src/coinify/payment-method.js
+++ b/src/coinify/payment-method.js
@@ -107,26 +107,18 @@ Object.defineProperties(PaymentMethod.prototype, {
 });
 
 PaymentMethod.fetchAll = function (inCurrency, outCurrency, coinify) {
-  var getPaymentMethods = function () {
-    var params = {};
-    if (inCurrency) { params.inCurrency = inCurrency; }
-    if (outCurrency) { params.outCurrency = outCurrency; }
+  var params = {};
+  if (inCurrency) { params.inCurrency = inCurrency; }
+  if (outCurrency) { params.outCurrency = outCurrency; }
 
-    var output = [];
-    return coinify.GET('trades/payment-methods', params).then(function (res) {
-      output.length = 0;
-      for (var i = 0; i < res.length; i++) {
-        output.push(new PaymentMethod(res[i], coinify));
-      }
-      return Promise.resolve(output);
-    });
-  };
-
-  if (coinify.isLoggedIn) {
-    return getPaymentMethods();
-  } else {
-    return coinify.login().then(getPaymentMethods);
-  }
+  var output = [];
+  return coinify.authGET('trades/payment-methods', params).then(function (res) {
+    output.length = 0;
+    for (var i = 0; i < res.length; i++) {
+      output.push(new PaymentMethod(res[i], coinify));
+    }
+    return Promise.resolve(output);
+  });
 };
 
 PaymentMethod.prototype.calculateFee = function (quote) {

--- a/src/coinify/profile.js
+++ b/src/coinify/profile.js
@@ -94,7 +94,7 @@ Object.defineProperties(CoinifyProfile.prototype, {
 
 CoinifyProfile.prototype.fetch = function () {
   var parentThis = this;
-  return this._coinify.GET('traders/me').then(function (res) {
+  return this._coinify.authGET('traders/me').then(function (res) {
     parentThis._full_name = res.profile.name;
     parentThis._gender = res.profile.gender;
 
@@ -180,5 +180,5 @@ CoinifyProfile.prototype.setZipcode = function (value) {
 };
 
 CoinifyProfile.prototype.update = function (values) {
-  return this._coinify.PATCH('traders/me', values);
+  return this._coinify.authPATCH('traders/me', values);
 };

--- a/src/coinify/quote.js
+++ b/src/coinify/quote.js
@@ -97,7 +97,7 @@ Quote.getQuote = function (coinify, amount, baseCurrency, quoteCurrency) {
     return quote;
   };
 
-  var getQuote = function () {
+  var getAnonymousQuote = function () {
     return coinify.POST('trades/quote', {
       baseCurrency: baseCurrency,
       quoteCurrency: quoteCurrency,
@@ -105,11 +105,16 @@ Quote.getQuote = function (coinify, amount, baseCurrency, quoteCurrency) {
     });
   };
 
-  if (coinify._offline_token == null) {
-    return getQuote().then(processQuote);
-  }
-  if (!coinify.isLoggedIn) {
-    return coinify.login().then(getQuote).then(processQuote);
+  var getQuote = function () {
+    return coinify.authPOST('trades/quote', {
+      baseCurrency: baseCurrency,
+      quoteCurrency: quoteCurrency,
+      baseAmount: parseFloat(baseAmount)
+    });
+  };
+
+  if (!coinify.hasAccount) {
+    return getAnonymousQuote().then(processQuote);
   } else {
     return getQuote().then(processQuote);
   }

--- a/tests/coinify/coinify_kyc_spec.js.coffee
+++ b/tests/coinify/coinify_kyc_spec.js.coffee
@@ -29,58 +29,52 @@ describe "KYC", ->
       expect(k._iSignThisID).toBe(o.externalId)
 
   describe "fetch all", ->
-    it "should call GET with the correct arguments ", (done) ->
+    it "should call authGET with the correct arguments ", (done) ->
 
       coinify = {
         _kycs: []
-        GET: (method, params) -> Promise.resolve([o,o,o,o]),
-        login: () -> Promise.resolve({access_token: 'my-token', expires_in: 1000})
+        authGET: (method, params) -> Promise.resolve([o,o,o,o]),
       }
-      spyOn(coinify, "GET").and.callThrough()
-      spyOn(coinify, "login").and.callThrough()
+      spyOn(coinify, "authGET").and.callThrough()
 
       promise = CoinifyKYC.fetchAll(coinify)
       testCalls = () ->
-        expect(coinify.GET).toHaveBeenCalledWith('kyc')
+        expect(coinify.authGET).toHaveBeenCalledWith('kyc')
       promise
         .then(testCalls)
         .then(done)
         .catch(console.log)
 
   describe "refresh", ->
-    it "should call GET with the correct arguments ", (done) ->
+    it "should call authGET with the correct arguments ", (done) ->
 
       coinify = {
         _kycs: []
-        GET: (method) -> Promise.resolve([o,o,o,o]),
-        login: () -> Promise.resolve({access_token: 'my-token', expires_in: 1000})
+        authGET: (method) -> Promise.resolve([o,o,o,o]),
       }
-      spyOn(coinify, "GET").and.callThrough()
-      spyOn(coinify, "login").and.callThrough()
+      spyOn(coinify, "authGET").and.callThrough()
       k = new CoinifyKYC(o, coinify)
 
       promise = k.refresh()
       testCalls = () ->
-        expect(coinify.GET).toHaveBeenCalledWith('kyc/' + k._id)
+        expect(coinify.authGET).toHaveBeenCalledWith('kyc/' + k._id)
       promise
         .then(testCalls)
         .then(done)
         .catch(console.log)
 
   describe "trigger", ->
-    it "should call GET with the correct arguments ", (done) ->
+    it "should authPOST traders/me/kyc with the correct arguments ", (done) ->
 
       coinify = {
         _kycs: []
-        POST: (method) -> Promise.resolve(o),
-        login: () -> Promise.resolve({access_token: 'my-token', expires_in: 1000})
+        authPOST: (method) -> Promise.resolve(o),
       }
-      spyOn(coinify, "POST").and.callThrough()
-      spyOn(coinify, "login").and.callThrough()
+      spyOn(coinify, "authPOST").and.callThrough()
 
       promise = CoinifyKYC.trigger(coinify)
       testCalls = () ->
-        expect(coinify.POST).toHaveBeenCalledWith('traders/me/kyc')
+        expect(coinify.authPOST).toHaveBeenCalledWith('traders/me/kyc')
       promise
         .then(testCalls)
         .then(done)

--- a/tests/coinify/coinify_payment_method_spec.js.coffee
+++ b/tests/coinify/coinify_payment_method_spec.js.coffee
@@ -44,13 +44,11 @@ describe "Payment method", ->
       expect(b._outPercentageFee).toBe(o.outPercentageFee)
 
   describe "fetch all", ->
-    it "should call get with the correct arguments ", (done) ->
+    it "should authGET trades/payment-methods with the correct arguments", (done) ->
       coinify = {
-        GET: (method, params) -> Promise.resolve([o,o,o,o]),
-        login: () -> Promise.resolve({access_token: 'my-token', expires_in: 1000})
+        authGET: (method, params) -> Promise.resolve([o,o,o,o]),
       }
-      spyOn(coinify, "GET").and.callThrough()
-      spyOn(coinify, "login").and.callThrough()
+      spyOn(coinify, "authGET").and.callThrough()
 
       promise = PaymentMethod.fetchAll('EUR', 'BTC', coinify)
       argument = {
@@ -58,7 +56,7 @@ describe "Payment method", ->
         outCurrency: 'BTC'
       }
       testCalls = () ->
-        expect(coinify.GET).toHaveBeenCalledWith('trades/payment-methods', argument)
+        expect(coinify.authGET).toHaveBeenCalledWith('trades/payment-methods', argument)
       promise
         .then(testCalls)
         .then(done)

--- a/tests/coinify/coinify_profile_spec.js.coffee
+++ b/tests/coinify/coinify_profile_spec.js.coffee
@@ -55,7 +55,7 @@ describe "CoinifyProfile", ->
           country: "NL"
       }
       coinify = {
-        GET: (method) -> {
+        authGET: (method) -> {
           then: (cb) ->
             cb({
               id: 1
@@ -77,16 +77,16 @@ describe "CoinifyProfile", ->
               catch: () ->
             }
         }
-        PATCH: () ->
+        authPATCH: () ->
       }
-      spyOn(coinify, "GET").and.callThrough()
-      spyOn(coinify, "PATCH").and.callThrough()
+      spyOn(coinify, "authGET").and.callThrough()
+      spyOn(coinify, "authPATCH").and.callThrough()
       p = new CoinifyProfile(coinify)
 
     describe "fetch()", ->
       it "calls /traders/me", ->
         p.fetch()
-        expect(coinify.GET).toHaveBeenCalledWith('traders/me')
+        expect(coinify.authGET).toHaveBeenCalledWith('traders/me')
 
       it "populates the profile", ->
         p.fetch()
@@ -107,7 +107,7 @@ describe "CoinifyProfile", ->
     describe "update()", ->
       it "should update", ->
         p.update({profile: {name: 'Jane Do'}})
-        expect(coinify.PATCH).toHaveBeenCalledWith('traders/me', {profile: { name: 'Jane Do' }})
+        expect(coinify.authPATCH).toHaveBeenCalledWith('traders/me', {profile: { name: 'Jane Do' }})
 
     describe "Setter", ->
       beforeEach ->

--- a/tests/coinify/coinify_quote_spec.js.coffee
+++ b/tests/coinify/coinify_quote_spec.js.coffee
@@ -37,37 +37,35 @@ describe "CoinifyQuote", ->
     describe "getQuote()", ->
       coinify = {
         POST: () -> Promise.resolve()
+        authPOST: () -> Promise.resolve()
       }
 
       beforeEach ->
         spyOn(coinify, "POST").and.callThrough()
+        spyOn(coinify, "authPOST").and.callThrough()
 
-      describe "when not logged in", ->
+      describe "without an account", ->
         it "should POST /trades/quote", ->
           Quote.getQuote(coinify, 1000, 'EUR', 'BTC')
           expect(coinify.POST).toHaveBeenCalled()
           expect(coinify.POST.calls.argsFor(0)[0]).toEqual('trades/quote')
 
-      describe "when logged in", ->
+      describe "with an account", ->
         beforeEach ->
-          coinify._offline_token = "token"
-          coinify.profile = {}
-          coinify.isLoggedIn = true
+          coinify.hasAccount = true
 
-        it "should POST /trades/quote", ->
+        it "should POST /trades/quote with credentials", ->
           Quote.getQuote(coinify, 1000, 'EUR', 'BTC')
-          expect(coinify.POST).toHaveBeenCalled()
-          expect(coinify.POST.calls.argsFor(0)[0]).toEqual('trades/quote')
+          expect(coinify.authPOST).toHaveBeenCalled()
+          expect(coinify.authPOST.calls.argsFor(0)[0]).toEqual('trades/quote')
 
         it "should convert cents", ->
           Quote.getQuote(coinify, 1000, 'EUR', 'BTC')
-          expect(coinify.POST).toHaveBeenCalled()
-          expect(coinify.POST.calls.argsFor(0)[1].baseAmount).toEqual(10)
+          expect(coinify.authPOST.calls.argsFor(0)[1].baseAmount).toEqual(10)
 
         it "should convert satoshis", ->
           Quote.getQuote(coinify, 100000000, 'BTC', 'EUR')
-          expect(coinify.POST).toHaveBeenCalled()
-          expect(coinify.POST.calls.argsFor(0)[1].baseAmount).toEqual(1)
+          expect(coinify.authPOST.calls.argsFor(0)[1].baseAmount).toEqual(1)
 
   describe "instance", ->
     describe "getters", ->

--- a/tests/coinify/coinify_spec.js.coffee
+++ b/tests/coinify/coinify_spec.js.coffee
@@ -208,25 +208,6 @@ describe "Coinify", ->
         promise = c.login()
         expect(promise).toBeRejected(done)
 
-    describe 'profile', ->
-      beforeEach ->
-        c._user = "user-1"
-        c._offline_token = "offline-token"
-        c._access_token = "access-token"
-        c._profile._did_fetch = true;
-        c._profile._full_name = "John Doe"
-        c._profile._default_currency = "EUR"
-
-      describe 'fullName', ->
-        it 'can be updated', () ->
-          c.profile.setFullName("Jane Doe")
-          expect(c.PATCH).toHaveBeenCalled()
-          expect(c.PATCH.calls.argsFor(0)[1].profile).toEqual({name: 'Jane Doe'})
-          expect(c.profile.fullName).toEqual('Jane Doe')
-
-      describe 'default currency', ->
-        pending()
-
     describe 'getBuyQuote', ->
       it 'should use Quote.getQuote', ->
         spyOn(Quote, "getQuote").and.callThrough()


### PR DESCRIPTION
I can set the base to `master` once #265 is merged.

This PR adds `authGET`, `authPOST` and `authPATCH` which take care of logging the user in and renewing the session if needed.