### PR TITLE
feat(BlockchainWallet): add function to get note placeholder

### DIFF
--- a/src/blockchain-wallet.js
+++ b/src/blockchain-wallet.js
@@ -750,6 +750,34 @@ Wallet.prototype.deleteNote = function (txHash) {
   MyWallet.syncWallet();
 };
 
+Wallet.prototype.getNotePlaceholder = function (filter, tx) {
+  // Given a filter and received transaction, returns the first label shared by both the output(s') hd addresses and the account, otherwise returns a string of length 0.
+  // If using no account filter or filtering by imported addresses, pass in a non-numeric string. It will use the first account found in the outputs as the filtered account.
+  if (tx.txType === 'received' && this.isUpgradedToHD) {
+    var account = parseInt(filter, 10);
+    var addresses = tx.processedOutputs.filter(function (processedOutput) { return processedOutput.identity >= 0; });
+    var indexesAndLabels = addresses.map(function (processedOutput) {
+      var coinType = processedOutput.coinType.split('/');
+      var addressIndex = coinType[2];
+      return {index: addressIndex, label: processedOutput.label};
+    });
+
+    if (addresses.length) {
+      var match = function (a, b, prop) {
+        var seen = [];
+        for (var i = 0, aLength = a.length; i < aLength; i++) seen[prop ? a[i][prop] : a[i]] = true;
+        for (var j = 0, bLength = b.length; j < bLength; j++) if (seen[prop ? b[j][prop] : b[j]]) return b[j];
+        return false;
+      };
+      if (isNaN(account)) account = addresses[0].identity;
+      var hdAddresses = this.hdwallet.accounts[account].receivingAddressesLabels;
+      var matchedLabel = match(indexesAndLabels, hdAddresses, 'index').label;
+      if (matchedLabel && matchedLabel.length) return matchedLabel;
+    }
+  }
+  return '';
+};
+
 Wallet.prototype.getMnemonic = function (password) {
   var seedHex = this.isDoubleEncrypted
       ? WalletCrypto.decryptSecretWithSecondPassword(this.hdwallet.seedHex, password, this.sharedKey, this.pbkdf2_iterations)

--- a/tests/blockchain_wallet_spec.js.coffee
+++ b/tests/blockchain_wallet_spec.js.coffee
@@ -53,7 +53,7 @@ describe "Blockchain-Wallet", ->
         'archived': false
         'xpriv': 'xprv9yko4kDvhYSdUcqK5e8naLwtGE1Ca57mwJ6JMB8WxeYq8t1w3PpiZfGGvLN6N6GEwLF8XuHnp8HeNLrWWviAjXxb2BFEiLaW2UgukMZ3Zva'
         'xpub': 'xpub6Ck9UFkpXuzvh6unBffnwUtcpFqgyXqdJX1u9ZY8Wz5p1gM5aw8y7TakmcEWLA9rJkc59BJzn61p3qqKSaqFkSPMbbhGA9YDNmphj9SKBVJ'
-        'address_labels': []
+        'address_labels': [{'index': 170, 'label': 'Utilities'}]
         'cache':
           'receiveAccount': 'xpub6FD59hfbH1UWQA9B8NP1C8bh3jc6i2tpM6b8f4Wi9gHWQttZbBBtEsDDZAiPsw7e3427SzvQsFu2sdubjbZHDQdqYXN6x3hTDCrG5bZFEhB'
           'changeAccount': 'xpub6FD59hfbH1UWRrY38bVLPPLPLxcA1XBqsQgB95AgsSWngxbwqPBMd5Z3of8PNicLwE9peQ9g4SeWWtBTzUKLwfjSioAg73RRh7dJ5rWYxM7'
@@ -634,6 +634,18 @@ describe "Blockchain-Wallet", ->
           expect(MyWallet.syncWallet).toHaveBeenCalled()
 
           expect(wallet.getNote("hash")).toEqual(undefined)
+
+        it "should have a placeholder given a received transaction and account filter", ->
+          outputs = [
+            {'identity':0, 'label':'Car', 'coinType':'0/0/171'},
+            {'identity':0, 'label':'Utilities', 'coinType':'0/0/170'}
+          ]
+
+          expect(wallet.getNotePlaceholder(0, {'txType':'received', 'processedOutputs':outputs})).toEqual('Utilities')
+
+          expect(wallet.getNotePlaceholder(0, {'txType':'sent', 'processedOutputs':outputs})).toEqual('')
+          
+          expect(wallet.getNotePlaceholder(0, {'txType':'transferred', 'processedOutputs':outputs})).toEqual('')
 
       describe ".getMnemonic", ->
         it "should return the mnemonic if the wallet is not encrypted", ->


### PR DESCRIPTION
Added getter for note placeholder. Similar to this function, but avoids unnecessary and time-consuming address derivation and instead matches indexes with labels:

https://github.com/blockchain/My-Wallet-V3-Frontend/blob/4e91f82e9e2bf1a235dacf9dd47348983a7796f1/assets/js/directives/transaction-note.directive.js#L23-L39