### PR TITLE
Card declined()

### DIFF
--- a/tests/coinify/coinify_trade_spec.js.coffee
+++ b/tests/coinify/coinify_trade_spec.js.coffee
@@ -115,7 +115,7 @@ describe "CoinifyTrade", ->
               requirements: []
               level: {name: '1'}
               nextLevel: {name: '2'}
-              state: 'undefined'
+              state: 'awaiting_transfer_in'
             })
             {
               catch: () ->
@@ -151,6 +151,21 @@ describe "CoinifyTrade", ->
         expect(trade.sendAmount).toEqual(3505)
         expect(trade.outAmount).toEqual(3505)
         expect(trade.outAmountExpected).toEqual(3505)
+
+      it "state should stay 'rejected' after card decline", ->
+        trade._isDeclined = true
+        trade.set(tradeJSON) # {state: 'awaiting_transfer_in'}
+        expect(trade.state).toEqual('rejected')
+
+    describe "declined()", ->
+      beforeEach ->
+        trade.set(tradeJSON)
+
+      it "should change state to rejected and set _isDeclined", ->
+        trade.declined()
+        expect(trade.state).toEqual('rejected')
+        expect(trade._isDeclined).toEqual(true)
+
 
     describe "cancel()", ->
       beforeEach ->


### PR DESCRIPTION
This should make #630 easier. Just call `declined()` on a trade object to change its state to `rejected`. It will even stay `rejected` if you `refresh()` the trade.

I intentionally did not make this generic for all states, because I don't think that's safe. 

Let me know if there are other states that need to be overridden. I suspect there's only a small number of cases where there are race conditions (the Coinify API lagging behind the iSignThis iframe) we need to deal with.