### PR TITLE
feat(Metadata): allow overriding of classes and methods in Obj-C

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,5 +40,9 @@ module.exports = {
   Metadata: require('./src/metadata'),
   Bitcoin: require('bitcoinjs-lib'),
   External: require('./src/external'),
-  BuySell: require('./src/buy-sell')
+  BuySell: require('./src/buy-sell'),
+  BigInteger: require('bigi/lib'),
+  BIP39: require('bip39'),
+  Networks: require('bitcoinjs-lib/src/networks'),
+  ECDSA: require('bitcoinjs-lib/src/ecdsa')
 };

--- a/src/metadata.js
+++ b/src/metadata.js
@@ -35,10 +35,10 @@ function Metadata (payloadType, cipher) {
   //                       signature used to authenticate
   // purpose' / type' / 1' : sha256(private key) used as 256 bit AES key
 
-  var node = payloadTypeNode.deriveHardened(0);
+  this._node = payloadTypeNode.deriveHardened(0);
 
-  this._address = node.getAddress();
-  this._signatureKeyPair = node.keyPair;
+  this._address = this._node.getAddress();
+  this._signatureKeyPair = this._node.keyPair;
 
   var privateKeyBuffer = payloadTypeNode.deriveHardened(1).keyPair.d.toBuffer();
   this._encryptionKey = WalletCrypto.sha256(privateKeyBuffer);
@@ -97,8 +97,7 @@ Metadata.prototype.fetch = function () {
 
       var decryptedPayload = WalletCrypto.decryptDataWithKey(serverPayload.payload, self._encryptionKey);
 
-      var verified = Bitcoin.message.verify(
-        self._address,
+      var verified = self._verify(
         Buffer(serverPayload.signature, 'base64'),
         serverPayload.payload
       );
@@ -118,6 +117,10 @@ Metadata.prototype.fetch = function () {
   });
 };
 
+// Overridden in Objective-C
+Metadata.prototype._verify = function (signature, message) {
+  return Bitcoin.message.verify(this._address, signature, message);
+};
 /*
 metadata.update({
   lastViewed: Date.now()


### PR DESCRIPTION
Exposed modules in index.js:

BigInteger (required for KeyPair getters to behave like ECPair's):
https://github.com/blockchain/My-Wallet-V3-iOS/blob/metadata-optimization/Blockchain/KeyPair.m#L42-L47

BIP39 (required for override for ~5 second save):
https://github.com/blockchain/My-Wallet-V3-iOS/blob/metadata-optimization/Blockchain/js/wallet-ios.js#L1375

Networks (required for Bitcoin network in JS, and later Testnet):
https://github.com/blockchain/My-Wallet-V3-iOS/blob/metadata-optimization/Blockchain/js/wallet-ios.js#L1891

ECDSA (required for sending): 
https://github.com/blockchain/My-Wallet-V3-iOS/blob/metadata-optimization/Blockchain/js/wallet-ios.js#L1895