### PR TITLE
fix(Index): make Symbol available in iOS 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
-require('es6-promise').polyfill();
 require('isomorphic-fetch');
+require('babel-polyfill');
 
 var Buffer = require('buffer').Buffer;
 


### PR DESCRIPTION
Requiring `babel-polyfill` is not the best solution here but requiring `es6-symbol/implement`doesn't seem to work (errors `TypeError: undefined is not a function (evaluating 'obj.trades[Symbol.iterator]()'`, where console logging `Symbol.iterator` returns `@@iterator`). Using `babel-polyfill` would add about 5k lines to `my-wallet.js`. Any ideas @Sjors ?

Some relevant discussion here:
https://github.com/yelouafi/redux-saga/issues/54#issuecomment-174353460