### PR TITLE
feat(WalletTransaction): add double spend key to iOS factory

### DIFF
--- a/src/wallet-transaction.js
+++ b/src/wallet-transaction.js
@@ -300,7 +300,9 @@ Tx.IOSfactory = function (tx) {
     to: tx.to,
     from: tx.from,
     fee: tx.fee,
-    note: tx.note
+    note: tx.note,
+    double_spend: tx.double_spend,
+    rbf: tx.rbf
   };
 };
 


### PR DESCRIPTION
Can someone show me where this rbf value is coming from? Can't seem to find it.

https://github.com/blockchain/My-Wallet-V3-Frontend/pull/446/commits/3199fd16b613974fadba30bbc7e6e2dffef463a8#diff-25c7c4d7d04ec870a640f4d84b0d8566R2