### PR TITLE
Send correct month to SFOX

### DIFF
--- a/src/sfox/profile.js
+++ b/src/sfox/profile.js
@@ -108,7 +108,7 @@ class Profile {
       zipcode: this.address.zipcode,
       country: this.address.country,
       birth_day: this.dateOfBirth.getDate(),
-      birth_month: this.dateOfBirth.getMonth(),
+      birth_month: this.dateOfBirth.getMonth() + 1,
       birth_year: this.dateOfBirth.getFullYear(),
       identity: this.identity
     }).then((res) => {


### PR DESCRIPTION
Javascript months index from 0, but SFOX uses 1-12.