### PR TITLE
Set newChecksum correctly

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -65,7 +65,7 @@ MyWallet.getSocketOnMessage = function (message, lastOnChange) {
 
   if (obj.op === 'on_change') {
     var oldChecksum = WalletStore.generatePayloadChecksum();
-    var newChecksum = obj.checksum;
+    var newChecksum = obj.x.checksum;
 
     if (lastOnChange.checksum !== newChecksum && oldChecksum !== newChecksum) {
       lastOnChange.checksum = newChecksum;


### PR DESCRIPTION
`newChecksum` was being set to undefined. The correct checksum is in obj.x.checksum.

This was causing the first on_change event, regardless if it was from the same wallet or not, to run a full `wallet.fetchAccountInfo(wallet.loadExternal);` and the subsequent checks to never get called since `lastOnChange.checksum = newChecksum;` would always be undefined.

This seemed like it was only happening on my dev environment, but only because I was using the wrong websocket URL for production.

