### PR TITLE
Make SJCL an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/blockchain/my-wallet-v3.git"
   },
   "scripts": {
-    "postinstall": "cd node_modules/sjcl || cd ../sjcl && ./configure --with-sha1 && make",
+    "postinstall": "(cd node_modules/sjcl || cd ../sjcl && ./configure --with-sha1 && make) || (echo 'SJCL was not configured'; exit 0)",
     "dist": "NODE_ENV=\"prod\" ./node_modules/.bin/webpack",
     "build": "./node_modules/.bin/webpack --progress",
     "build:watch": "./node_modules/.bin/webpack -w",
@@ -47,11 +47,13 @@
     "pbkdf2": "3.0.4",
     "ramda": "^0.22.1",
     "randombytes": "^2.0.1",
-    "sjcl": "1.0.3",
     "unorm": "^1.4.1",
     "ws": "2.0.*",
     "bitcoin-coinify-client": "^0.3.2",
     "bitcoin-sfox-client": "0.1.*"
+  },
+  "optionalDependencies": {
+    "sjcl": "1.0.3"
   },
   "devDependencies": {
     "babel-plugin-transform-object-assign": "~6.22.0",

--- a/src/wallet-crypto.js
+++ b/src/wallet-crypto.js
@@ -2,7 +2,12 @@
 
 var crypto = require('crypto');
 var assert = require('assert');
-var sjcl = require('sjcl');
+
+try {
+  // SJCL may not be installed if in node environment
+  var sjcl = require('sjcl');
+} catch (e) {
+}
 
 var SUPPORTED_ENCRYPTION_VERSION = 3;
 var SALT_BYTES = 16;
@@ -321,10 +326,10 @@ function decryptDataWithPassword (data, password, iterations, options) {
   return res;
 }
 
-function stretchPassword (password, salt, iterations, keylen) {
+function stretchPasswordSJCL (password, salt, iterations, keyLenBits) {
   assert(salt, 'salt missing');
-  assert(password, 'password missing');
-  assert(iterations, 'iterations missing');
+  assert(typeof password === 'string', 'password string required');
+  assert(typeof iterations === 'number' && !isNaN(iterations), 'iterations number required');
   assert(typeof (sjcl.hash.sha1) === 'function', 'missing sha1, make sure sjcl is configured correctly');
 
   var hmacSHA1 = function (key) {
@@ -333,14 +338,25 @@ function stretchPassword (password, salt, iterations, keylen) {
   };
 
   salt = sjcl.codec.hex.toBits(salt.toString('hex'));
-  var stretched = sjcl.misc.pbkdf2(password, salt, iterations, keylen || 256, hmacSHA1);
+  var stretched = sjcl.misc.pbkdf2(password, salt, iterations, keyLenBits || 256, hmacSHA1);
 
   return new Buffer(sjcl.codec.hex.fromBits(stretched), 'hex');
 }
 
-function pbkdf2 (password, salt, iterations, keylen, algorithm) {
+function stretchPasswordCrypto (password, salt, iterations, keyLenBits) {
+  assert(salt, 'salt missing');
+  assert(typeof password === 'string', 'password string required');
+  assert(typeof iterations === 'number' && !isNaN(iterations), 'iterations number required');
+  assert(keyLenBits == null || keyLenBits % 8 === 0, 'key length must be evenly divisible into bytes');
+
+  salt = new Buffer(salt, 'hex');
+  var keyLenBytes = (keyLenBits || 256) / 8;
+  return pbkdf2(password, salt, iterations, keyLenBytes, ALGO.SHA1);
+}
+
+function pbkdf2 (password, salt, iterations, keyLenBytes, algorithm) {
   algorithm = algorithm || ALGO.SHA1;
-  return crypto.pbkdf2Sync(password, salt, iterations, keylen, algorithm);
+  return crypto.pbkdf2Sync(password, salt, iterations, keyLenBytes, algorithm);
 }
 
 function hashNTimes (data, iterations) {
@@ -574,7 +590,7 @@ module.exports = {
   decryptPasswordWithProcessedPin: decryptPasswordWithProcessedPin,
   decrypt: decryptDataWithPassword,
   encrypt: encryptDataWithPassword,
-  stretchPassword: stretchPassword,
+  stretchPassword: sjcl == null ? stretchPasswordCrypto : stretchPasswordSJCL,
   pbkdf2: pbkdf2,
   hashNTimes: hashNTimes,
   sha256: sha256,


### PR DESCRIPTION
This is to get rid of a headache I've had for too long... The SJCL install process. I think what I've done here is a good solution, but would appreciate extra eyes on it of course...

I've moved SJCL to optionalDependencies, which will be skipped over when running `npm install` with the `--no-optional` flag. Then, if SJCL isn't available, the stretchPassword function will switch to a version that uses `'crypto'` (which is always available). ~The tests pass with and without SJCL installed, but without SJCL you need to add `bundle.exclude('sjcl')` to the browserify options in karma.config.js (otherwise browserify will error out before the tests can run)~ EDIT: added tests that will mock the absence of SJCL, without you having to manually uninstall and modify karma.config.

cc @pernas @Sjors @kristovatlas 