### PR TITLE
Do not use KV store for Labels

### DIFF
--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -211,7 +211,7 @@ HDAccount.prototype.toJSON = function () {
     archived: this._archived,
     xpriv: this._xpriv,
     xpub: this._xpub,
-    address_labels: this._address_labels,
+    address_labels: this._address_labels.sort(o => o.index),
     cache: this._keyRing
   };
 
@@ -267,7 +267,9 @@ HDAccount.prototype.addLabel = function (receiveIndex, label) {
 };
 
 HDAccount.prototype.getLabels = function () {
-  return this._address_labels.map(o => ({index: o.index, label: o.label}));
+  return this._address_labels
+          .sort(o => o.index)
+          .map(o => ({index: o.index, label: o.label}));
 };
 
 HDAccount.prototype.setLabel = function (receiveIndex, label) {

--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -267,7 +267,7 @@ HDAccount.prototype.addLabel = function (receiveIndex, label) {
 };
 
 HDAccount.prototype.getLabels = function () {
-  return JSON.parse(JSON.stringify(this._address_labels));
+  return this._address_labels.map(o => ({index: o.index, label: o.label}));
 };
 
 HDAccount.prototype.setLabel = function (receiveIndex, label) {

--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -1,5 +1,3 @@
-'use strict';
-
 module.exports = HDAccount;
 
 var Bitcoin = require('bitcoinjs-lib');
@@ -251,4 +249,42 @@ HDAccount.prototype.persist = function () {
   this._xpriv = this._temporal_xpriv;
   delete this._temporal_xpriv;
   return this;
+};
+
+// Address labels:
+
+HDAccount.prototype.addLabel = function (receiveIndex, label) {
+  assert(Helpers.isPositiveInteger(receiveIndex));
+
+  let labels = this._address_labels;
+
+  let labelEntry = {
+    index: receiveIndex,
+    label: label
+  };
+
+  labels.push(labelEntry);
+};
+
+HDAccount.prototype.getLabels = function () {
+  return JSON.parse(JSON.stringify(this._address_labels));
+};
+
+HDAccount.prototype.setLabel = function (receiveIndex, label) {
+  let labels = this._address_labels;
+
+  let labelEntry = labels.find((label) => label.index === receiveIndex);
+
+  if (!labelEntry) {
+    labelEntry = {index: receiveIndex};
+    labels.push(labelEntry);
+  }
+
+  labelEntry.label = label;
+};
+
+HDAccount.prototype.removeLabel = function (receiveIndex) {
+  let labels = this._address_labels;
+  let labelEntry = labels.find((label) => label.index === receiveIndex);
+  labels.splice(labels.indexOf(labelEntry), 1);
 };

--- a/src/hd-account.js
+++ b/src/hd-account.js
@@ -211,7 +211,7 @@ HDAccount.prototype.toJSON = function () {
     archived: this._archived,
     xpriv: this._xpriv,
     xpub: this._xpub,
-    address_labels: this._address_labels.sort(o => o.index),
+    address_labels: this._orderedAddressLabels(),
     cache: this._keyRing
   };
 
@@ -253,6 +253,10 @@ HDAccount.prototype.persist = function () {
 
 // Address labels:
 
+HDAccount.prototype._orderedAddressLabels = function () {
+  return this._address_labels.sort((a, b) => a.index - b.index);
+};
+
 HDAccount.prototype.addLabel = function (receiveIndex, label) {
   assert(Helpers.isPositiveInteger(receiveIndex));
 
@@ -268,7 +272,7 @@ HDAccount.prototype.addLabel = function (receiveIndex, label) {
 
 HDAccount.prototype.getLabels = function () {
   return this._address_labels
-          .sort(o => o.index)
+          .sort((a, b) => a.index - b.index)
           .map(o => ({index: o.index, label: o.label}));
 };
 

--- a/src/labels.js
+++ b/src/labels.js
@@ -33,7 +33,7 @@ class Labels {
       }
 
       // Add null entries up to the current (labeled) receive index
-      for (let i = 0; i < Math.max(receiveIndex, addresses.length - 1); i++) {
+      for (let i = 0; i < Math.max(receiveIndex + 1, addresses.length); i++) {
         if (!addresses[i]) {
           addresses[i] = new AddressHD(null,
                         hdAccount,
@@ -70,8 +70,8 @@ class Labels {
   // this is an implementation detail and we don't save it.
   checkIfUsed (accountIndex) {
     assert(Helpers.isPositiveInteger(accountIndex), 'specify accountIndex');
-    let labeledAddresses = this.all(accountIndex).filter((a) => a !== null);
-    let addresses = labeledAddresses.filter((a) => a.label !== null).map((a) => a.address);
+    let labeledAddresses = this.all(accountIndex).filter((a) => a !== null && a.label !== null);
+    let addresses = labeledAddresses.map((a) => a.address);
     if (addresses.length === 0) return Promise.resolve();
 
     return BlockchainAPI.getBalances(addresses).then((data) => {

--- a/src/labels.js
+++ b/src/labels.js
@@ -9,12 +9,7 @@ class Labels {
     assert(syncWallet instanceof Function, 'syncWallet function required');
     this._wallet = wallet;
 
-    this._syncWallet = () => Promise.resolve().then(() => {
-      syncWallet(
-        () => Promise.resolve(),
-        (e) => Promise.reject(e)
-      );
-    });
+    this._syncWallet = () => new Promise(syncWallet);
 
     this.init();
   }

--- a/src/labels.js
+++ b/src/labels.js
@@ -9,7 +9,12 @@ class Labels {
     assert(syncWallet instanceof Function, 'syncWallet function required');
     this._wallet = wallet;
 
-    this._syncWallet = syncWallet;
+    this._syncWallet = () => Promise.resolve().then(() => {
+      syncWallet(
+        () => Promise.resolve(),
+        (e) => Promise.reject(e)
+      );
+    });
 
     this.init();
   }
@@ -51,13 +56,6 @@ class Labels {
 
   get readOnly () {
     return false;
-  }
-
-  syncWallet () {
-    const syncWallet = () => {
-      this._syncWallet(() => Promise.resolve(), (e) => Promise.reject(e));
-    };
-    return Promise.resolve().then(syncWallet);
   }
 
   // For debugging only, not used to save.
@@ -186,7 +184,7 @@ class Labels {
     };
     labels.push(labelEntry);
 
-    return this.syncWallet().then(() => {
+    return this._syncWallet().then(() => {
       return addr;
     });
   }
@@ -232,7 +230,7 @@ class Labels {
 
     labelEntry.label = label;
 
-    return this.syncWallet();
+    return this._syncWallet();
   }
 
   removeLabel (accountIndex, address) {
@@ -259,7 +257,7 @@ class Labels {
     let labelEntry = labels.find((label) => label.index === addressIndex);
     labels.splice(labels.indexOf(labelEntry), 1);
 
-    return this.syncWallet();
+    return this._syncWallet();
   }
 
   // options:

--- a/src/labels.js
+++ b/src/labels.js
@@ -27,12 +27,7 @@ class Labels {
       let receiveIndex = hdAccount.receiveIndex;
       let addresses = [];
 
-      let maxLabeledReceiveIndex = -1;
-
-      for (let addressLabel of hdAccount._address_labels) {
-        if (addressLabel.index > maxLabeledReceiveIndex) {
-          maxLabeledReceiveIndex = addressLabel.index;
-        }
+      for (let addressLabel of hdAccount.getLabels()) {
         addresses[addressLabel.index] = new AddressHD(
           {
             label: addressLabel.label
@@ -43,7 +38,7 @@ class Labels {
       }
 
       // Add null entries up to the current (labeled) receive index
-      for (let i = 0; i < Math.max(receiveIndex, maxLabeledReceiveIndex); i++) {
+      for (let i = 0; i < Math.max(receiveIndex, addresses.length - 1); i++) {
         if (!addresses[i]) {
           addresses[i] = new AddressHD(null,
                         hdAccount,
@@ -176,13 +171,7 @@ class Labels {
     addr.used = false;
 
     // Update wallet:
-    let labels = this._wallet.hdwallet.accounts[accountIndex]._address_labels;
-
-    let labelEntry = {
-      index: receiveIndex,
-      label: label
-    };
-    labels.push(labelEntry);
+    this._wallet.hdwallet.accounts[accountIndex].addLabel(receiveIndex, label);
 
     return this._syncWallet().then(() => {
       return addr;
@@ -218,17 +207,8 @@ class Labels {
 
     address.label = label;
 
-    let labels = this._wallet.hdwallet.accounts[accountIndex]._address_labels;
-
     // Update in wallet:
-    let labelEntry = labels.find((label) => label.index === receiveIndex);
-
-    if (!labelEntry) {
-      labelEntry = {index: receiveIndex};
-      labels.push(labelEntry);
-    }
-
-    labelEntry.label = label;
+    this._wallet.hdwallet.accounts[accountIndex].setLabel(receiveIndex, label);
 
     return this._syncWallet();
   }
@@ -253,9 +233,7 @@ class Labels {
     address.label = null;
 
     // Remove from wallet:
-    let labels = this._wallet.hdwallet.accounts[accountIndex]._address_labels;
-    let labelEntry = labels.find((label) => label.index === addressIndex);
-    labels.splice(labels.indexOf(labelEntry), 1);
+    this._wallet.hdwallet.accounts[accountIndex].removeLabel(addressIndex);
 
     return this._syncWallet();
   }

--- a/tests/hdaccount_spec.js
+++ b/tests/hdaccount_spec.js
@@ -282,6 +282,10 @@ describe('HDAccount', () => {
         it('should return a copy of _address_labels', () => {
           expect(account.getLabels()).toEqual(account._address_labels);
         });
+        it('should sort _address_labels by index', () => {
+          account._address_labels = [{index: 1, label: 'One'}, {index: 0, label: 'Zero'}];
+          expect(account.getLabels()).toEqual([{index: 0, label: 'Zero'}, {index: 1, label: 'One'}]);
+        });
       });
 
       describe('addLabel()', () => {

--- a/tests/hdaccount_spec.js
+++ b/tests/hdaccount_spec.js
@@ -4,22 +4,23 @@ let HDAccount;
 
 // TODO: use more mocks, this file takes 7 seconds to run
 describe('HDAccount', () => {
-  let account;
-  let object = {
-    'label': 'My great wallet',
-    'archived': false,
-    'xpriv': 'xprv9zJ1cTHnqzgBXr9Uq9jXrdbk2LwApa3Vu6dquzhmckQyj1hvK9xugPNsycfveTGcTy2571Rq71daBpe1QESUsjX7d2ZHVVXEwJEwDiiMD7E',
-    'xpub': 'xpub6DHN1xpggNEUkLDwwBGYDmYUaNmfE2mMGKZSiP7PB5wxbp34rhHAEBhMpsjHEwZWsHY2kPmPPD1w6gxGSBe3bXQzCn2WV8FRd7ZKpsiGHMq',
-    'address_labels': [{'index': 3, 'label': 'Hello'}], // Backwards compatibility
-    'cache': {
-      'receiveAccount': 'xpub6FMWuMox3fJxEv2TSLN6jYQg6tHZBS7tKRSu7w4Q7F9K2UsSu4RxtwxfeHVhUv3csTSCRkKREpiVdr8EquBPXfBDZSMe84wmN9LzR3rwNZP',
-      'changeAccount': 'xpub6FMWuMox3fJxGARtaDVY6e9st4Hk5j8Ui6r7XLnBPFXPXkajXNiAfiEqBakuDKYYeRf4ERtPm1TawBqKaBWj2dsHNJT4rSsugssTnaDsz2m'
-    }
-  };
+  let account, object;
 
   let maxLabeledReceiveIndex = -1;
 
   beforeEach(() => {
+    object = {
+      'label': 'My great wallet',
+      'archived': false,
+      'xpriv': 'xprv9zJ1cTHnqzgBXr9Uq9jXrdbk2LwApa3Vu6dquzhmckQyj1hvK9xugPNsycfveTGcTy2571Rq71daBpe1QESUsjX7d2ZHVVXEwJEwDiiMD7E',
+      'xpub': 'xpub6DHN1xpggNEUkLDwwBGYDmYUaNmfE2mMGKZSiP7PB5wxbp34rhHAEBhMpsjHEwZWsHY2kPmPPD1w6gxGSBe3bXQzCn2WV8FRd7ZKpsiGHMq',
+      'address_labels': [{'index': 3, 'label': 'Hello'}],
+      'cache': {
+        'receiveAccount': 'xpub6FMWuMox3fJxEv2TSLN6jYQg6tHZBS7tKRSu7w4Q7F9K2UsSu4RxtwxfeHVhUv3csTSCRkKREpiVdr8EquBPXfBDZSMe84wmN9LzR3rwNZP',
+        'changeAccount': 'xpub6FMWuMox3fJxGARtaDVY6e9st4Hk5j8Ui6r7XLnBPFXPXkajXNiAfiEqBakuDKYYeRf4ERtPm1TawBqKaBWj2dsHNJT4rSsugssTnaDsz2m'
+      }
+    };
+
     MyWallet = {
       syncWallet () {},
       wallet: {
@@ -274,6 +275,43 @@ describe('HDAccount', () => {
     });
 
     describe('Getter', () => {
+    });
+
+    describe('Labeled addresses', () => {
+      describe('getLabels()', () => {
+        it('should return a copy of _address_labels', () => {
+          expect(account.getLabels()).toEqual(account._address_labels);
+        });
+      });
+
+      describe('addLabel()', () => {
+        it('should push a label entry', () => {
+          let before = account._address_labels.length;
+          account.addLabel(2, 'New Label');
+          expect(account._address_labels.length).toEqual(before + 1);
+        });
+      });
+
+      describe('setLabel()', () => {
+        it('should update existing label entry', () => {
+          account.setLabel(3, 'Updated Label');
+          expect(account._address_labels[0].label).toEqual('Updated Label');
+        });
+
+        it('should push a label entry if none exists', () => {
+          let before = account._address_labels.length;
+          account.setLabel(2, 'New Label');
+          expect(account._address_labels.length).toEqual(before + 1);
+        });
+      });
+
+      describe('removeLabel()', () => {
+        it('should remove a label entry', () => {
+          let before = account._address_labels.length;
+          account.removeLabel(3);
+          expect(account._address_labels.length).toEqual(before - 1);
+        });
+      });
     });
 
     describe('.encrypt', () => {

--- a/tests/labels_spec.js
+++ b/tests/labels_spec.js
@@ -155,32 +155,32 @@ describe('Labels', () => {
     });
 
     describe('setLabel()', () => {
-      it('should call syncWallet()', () => {
-        spyOn(l, 'syncWallet');
+      it('should call _syncWallet()', () => {
+        spyOn(l, '_syncWallet');
         l.setLabel(0, 1, 'Updated Label');
-        expect(l.syncWallet).toHaveBeenCalled();
+        expect(l._syncWallet).toHaveBeenCalled();
       });
 
-      it('should not call syncWallet() if label is unchanged', () => {
-        spyOn(l, 'syncWallet');
+      it('should not call _syncWallet() if label is unchanged', () => {
+        spyOn(l, '_syncWallet');
         l.setLabel(0, 1, 'Hello');
-        expect(l.syncWallet).not.toHaveBeenCalled();
+        expect(l._syncWallet).not.toHaveBeenCalled();
       });
     });
 
     describe('addLabel()', () => {
-      it('should call syncWallet()', () => {
-        spyOn(l, 'syncWallet').and.callThrough();
+      it('should call _syncWallet()', () => {
+        spyOn(l, '_syncWallet').and.callThrough();
         l.addLabel(0, 15, 'New Label');
-        expect(l.syncWallet).toHaveBeenCalled();
+        expect(l._syncWallet).toHaveBeenCalled();
       });
     });
 
     describe('removeLabel()', () => {
-      it('should call syncWallet()', () => {
-        spyOn(l, 'syncWallet');
+      it('should call _syncWallet()', () => {
+        spyOn(l, '_syncWallet');
         l.removeLabel(0, 1);
-        expect(l.syncWallet).toHaveBeenCalled();
+        expect(l._syncWallet).toHaveBeenCalled();
       });
     });
 

--- a/tests/labels_spec.js
+++ b/tests/labels_spec.js
@@ -61,6 +61,22 @@ describe('Labels', () => {
           l = new Labels(wallet);
         }).toThrow();
       });
+
+      it('should wrap syncWallet in a promise (resolve)', (done) => {
+        let syncWalletSuccess = (success, error) => { success(); };
+
+        l = new Labels(wallet, syncWalletSuccess);
+
+        expect(l._syncWallet()).toBeResolved(done);
+      });
+
+      it('should wrap syncWallet in a promise (reject)', (done) => {
+        let syncWalletFail = (success, error) => { error(); };
+
+        l = new Labels(wallet, syncWalletFail);
+
+        expect(l._syncWallet()).toBeRejected(done);
+      });
     });
   });
 

--- a/tests/labels_spec.js
+++ b/tests/labels_spec.js
@@ -27,16 +27,23 @@ describe('Labels', () => {
 
   let l;
 
+  let account;
+
   beforeEach(() => {
+    account = {
+      index: 0,
+      receiveAddressAtIndex: (index) => `0-${index}`,
+      receiveIndex: 2,
+      lastUsedReceiveIndex: 1,
+      getLabels: () => [{index: 1, label: 'Hello'}],
+      addLabel: () => {},
+      setLabel: () => {},
+      removeLabel: () => {}
+    };
+
     wallet = {
       hdwallet: {
-        accounts: [{
-          index: 0,
-          receiveAddressAtIndex: (index) => `0-${index}`,
-          receiveIndex: 2,
-          lastUsedReceiveIndex: 1,
-          _address_labels: [{index: 1, label: 'Hello'}]
-        }]
+        accounts: [account]
       }
     };
   });
@@ -155,6 +162,12 @@ describe('Labels', () => {
     });
 
     describe('setLabel()', () => {
+      it('should call account.setLabel()', () => {
+        spyOn(account, 'setLabel').and.callThrough();
+        l.setLabel(0, 1, 'Updated Label');
+        expect(account.setLabel).toHaveBeenCalledWith(1, 'Updated Label');
+      });
+
       it('should call _syncWallet()', () => {
         spyOn(l, '_syncWallet');
         l.setLabel(0, 1, 'Updated Label');
@@ -169,6 +182,12 @@ describe('Labels', () => {
     });
 
     describe('addLabel()', () => {
+      it('should call account.addLabel()', () => {
+        spyOn(account, 'addLabel').and.callThrough();
+        l.addLabel(0, 15, 'New Label');
+        expect(account.addLabel).toHaveBeenCalledWith(2, 'New Label');
+      });
+
       it('should call _syncWallet()', () => {
         spyOn(l, '_syncWallet').and.callThrough();
         l.addLabel(0, 15, 'New Label');
@@ -177,6 +196,12 @@ describe('Labels', () => {
     });
 
     describe('removeLabel()', () => {
+      it('should call account.removeLabel()', () => {
+        spyOn(account, 'removeLabel').and.callThrough();
+        l.removeLabel(0, 1);
+        expect(account.removeLabel).toHaveBeenCalledWith(1);
+      });
+
       it('should call _syncWallet()', () => {
         spyOn(l, '_syncWallet');
         l.removeLabel(0, 1);


### PR DESCRIPTION
`addLabel`, `setLabel` and `removeLabel` now write directly to `MyWallet.wallet.accounts[n]._address_labels` and then trigger a sync.

This will make it easier to move this data to the KV store in a future update.

I haven't looked into the performance issues yet, although I think those can be solved fully on the frontend side.