### PR TITLE
Correctly use typeId default

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -18,7 +18,7 @@ class Metadata {
     // encKeyBuffer :: Buffer (nullable = no encrypted save)
     // TypeId :: Int (nullable = default -1)
     this.VERSION = 1;
-    this._typeId = typeId || -1;
+    this._typeId = typeId == null ? -1 : typeId;
     this._magicHash = null;
     this._address = ecPair.getAddress();
     this._signKey = ecPair;


### PR DESCRIPTION
Before, this was just checking for a falsy value, so the guid kv entry (which has typeId=0) would use the default value of -1.