### PR TITLE
Initialize external kv from correct node

### DIFF
--- a/src/external.js
+++ b/src/external.js
@@ -88,7 +88,7 @@ External.prototype.toJSON = function () {
 };
 
 External.initMetadata = function (wallet) {
-  return Metadata.fromMasterHDNode(wallet._metadataHDNode, METADATA_TYPE_EXTERNAL);
+  return Metadata.fromMetadataHDNode(wallet._metadataHDNode, METADATA_TYPE_EXTERNAL);
 };
 
 External.fromJSON = function (wallet, json, magicHash) {

--- a/tests/external_spec.js
+++ b/tests/external_spec.js
@@ -20,7 +20,7 @@ describe('External', () => {
   };
 
   let Metadata = {
-    fromMasterHDNode (n, masterhdnode) {
+    fromMetadataHDNode (n, masterhdnode) {
       return metaDataInstance;
     }
   };


### PR DESCRIPTION
This bug probably would have been detected if these tests weren't so heavily mocked. Should really avoid mocking when possible, otherwise our tests start to fit the mocks better than the actual code and seem to become unrealistic.