### PR TITLE
Reload external metadata after a sync

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -128,7 +128,9 @@ MyWallet.getWallet = function (success, error) {
     MyWallet.decryptAndInitializeWallet(function () {
       MyWallet.wallet.getHistory();
 
-      if (success) success();
+      MyWallet.wallet.loadExternal().then(function () {
+        if (success) success();
+      });
     }, function () {
       // When re-fetching the wallet after a remote update, if we can't decrypt
       // it, logout for safety.


### PR DESCRIPTION
*Issue*

After a failed sync or an on_change message, the wallet would call getWallet, which reinitializes the wallet object. Doing this deletes the external data needed to decide whether of not to show the Buy tab.

*Fix*

Reload external data after the wallet is reinitialized. Ideally we wouldn't do another API call, but my-wallet-v3 isn't set up in a way that allows easy data de/serialization right now.