### PR TITLE
Validate pk checksum

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -323,11 +323,23 @@ Helpers.privateKeyStringToKey = function (value, format) {
     return Bitcoin.ECPair.fromWIF(value, constants.getNetwork());
   } else {
     var keyBuffer = null;
-    if (format === 'base58') keyBuffer = Base58.decode(value);
-    else if (format === 'base64') keyBuffer = new Buffer(value, 'base64');
-    else if (format === 'hex') keyBuffer = new Buffer(value, 'hex');
-    else if (format === 'mini') keyBuffer = parseMiniKey(value);
-    else throw new Error('Unsupported Key Format');
+
+    switch (format) {
+      case 'base58':
+        keyBuffer = Base58.decode(value);
+        break;
+      case 'base64':
+        keyBuffer = new Buffer(value, 'base64');
+        break;
+      case 'hex':
+        keyBuffer = new Buffer(value, 'hex');
+        break;
+      case 'mini':
+        keyBuffer = parseMiniKey(value);
+        break;
+      default:
+        throw new Error('Unsupported Key Format');
+    }
 
     var d = BigInteger.fromBuffer(keyBuffer);
     return new Bitcoin.ECPair(d, null, { network: constants.getNetwork() });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -319,37 +319,19 @@ function parseMiniKey (miniKey) {
 }
 
 Helpers.privateKeyStringToKey = function (value, format) {
-  var keyBytes = null;
-  var tbytes;
-
-  if (format === 'base58') {
-    keyBytes = Helpers.buffertoByteArray(Base58.decode(value));
-  } else if (format === 'base64') {
-    keyBytes = Helpers.buffertoByteArray(new Buffer(value, 'base64'));
-  } else if (format === 'hex') {
-    keyBytes = Helpers.buffertoByteArray(new Buffer(value, 'hex'));
-  } else if (format === 'mini') {
-    keyBytes = Helpers.buffertoByteArray(parseMiniKey(value));
-  } else if (format === 'sipa') {
-    tbytes = Helpers.buffertoByteArray(Base58.decode(value));
-    tbytes.shift(); // extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
-    tbytes.shift();
-    keyBytes = tbytes.slice(0, tbytes.length - 4);
-  } else if (format === 'compsipa') {
-    tbytes = Helpers.buffertoByteArray(Base58.decode(value));
-    tbytes.shift(); // extra shift cuz BigInteger.fromBuffer prefixed extra 0 byte to array
-    tbytes.shift();
-    tbytes.pop();
-    keyBytes = tbytes.slice(0, tbytes.length - 4);
+  if (format === 'sipa' || format === 'compsipa') {
+    return Bitcoin.ECPair.fromWIF(value, constants.getNetwork());
   } else {
-    throw new Error('Unsupported Key Format');
-  }
+    var keyBuffer = null;
+    if (format === 'base58') keyBuffer = Base58.decode(value);
+    else if (format === 'base64') keyBuffer = new Buffer(value, 'base64');
+    else if (format === 'hex') keyBuffer = new Buffer(value, 'hex');
+    else if (format === 'mini') keyBuffer = parseMiniKey(value);
+    else throw new Error('Unsupported Key Format');
 
-  return new Bitcoin.ECPair(
-    new BigInteger.fromByteArrayUnsigned(keyBytes), // eslint-disable-line new-cap
-    null,
-    { compressed: format !== 'sipa', network: constants.getNetwork() }
-  );
+    var d = BigInteger.fromBuffer(keyBuffer);
+    return new Bitcoin.ECPair(d, null, { network: constants.getNetwork() });
+  }
 };
 
 Helpers.detectPrivateKeyFormat = function (key) {

--- a/tests/helpers_spec.js
+++ b/tests/helpers_spec.js
@@ -291,6 +291,12 @@ describe('Helpers', () => {
       expect(res.getAddress()).toEqual(data.addr);
     }));
 
+    it('should fail given a key with an invalid checksum', () => {
+      let e = new Error('Invalid checksum');
+      let badKey = 'L3dDv2KUyLfPwkcnhALEaHnd47gewa1BVvnCwWL3gVWsb2H27xyz';
+      expect(() => Helpers.privateKeyStringToKey(badKey, 'compsipa')).toThrow(e);
+    });
+
     it('should fail if given an unknown format', () => {
       let e = new Error('Unsupported Key Format');
       expect(() => Helpers.privateKeyStringToKey('', 'unknown')).toThrow(e);

--- a/tests/helpers_spec.js
+++ b/tests/helpers_spec.js
@@ -285,17 +285,25 @@ describe('Helpers', () => {
       { format: 'compsipa', key: 'L3dDv2KUyLfPwkcnhALEaHnd47gewa1BVvnCwWL3gVWsb2H27PY9', addr: '1Mum7V38a3fGLiXN3oCrzdf83mZUKNXmGq' }
     ];
 
+    let errorFixtures = [
+      { format: 'base58', key: 'DXuhJcNCPfgjYN8NQFjVh9yri8Rau5B7ixWJjpSeqW7=', error: 'Non-base58 character' },
+      { format: 'base64', key: 'pbc8OCl5SdqjILx4R+yfvljZ7edUr65osjkzjqH2YQw+', error: 'Private key must be less than the curve order' },
+      { format: 'hex', key: 'abcdefg', error: 'Invalid hex string' },
+      { format: 'mini', key: 'S6c56bnXQiBjk9mqSYE7ykVQ7NzrRz', error: 'Invalid mini key' },
+      { format: 'sipa', key: '5JFXNQvtFZSobCCRPxnTZiW1PDVnXvGBg5XeuUDoUCi8LRsVxyz', error: 'Invalid checksum' },
+      { format: 'compsipa', key: 'L3dDv2KUyLfPwkcnhALEaHnd47gewa1BVvnCwWL3gVWsb2H27xyz', error: 'Invalid checksum' }
+    ];
+
     fixtures.forEach(data => it(`should convert ${data.format} format`, () => {
       let res = Helpers.privateKeyStringToKey(data.key, data.format);
       expect(Helpers.isKey(res)).toBeTruthy();
       expect(res.getAddress()).toEqual(data.addr);
     }));
 
-    it('should fail given a key with an invalid checksum', () => {
-      let e = new Error('Invalid checksum');
-      let badKey = 'L3dDv2KUyLfPwkcnhALEaHnd47gewa1BVvnCwWL3gVWsb2H27xyz';
-      expect(() => Helpers.privateKeyStringToKey(badKey, 'compsipa')).toThrow(e);
-    });
+    errorFixtures.forEach(data => it(`should fail for ${data.format} given a bad key`, () => {
+      let e = new Error(data.error);
+      expect(() => Helpers.privateKeyStringToKey(data.key, data.format)).toThrow(e);
+    }));
 
     it('should fail if given an unknown format', () => {
       let e = new Error('Unsupported Key Format');

--- a/tests/helpers_spec.js
+++ b/tests/helpers_spec.js
@@ -275,12 +275,27 @@ describe('Helpers', () => {
     });
   });
 
-  describe('privateKeyStringToKey', () =>
-    it('should convert sipa format', () => {
-      let res = Helpers.privateKeyStringToKey('5JFXNQvtFZSobCCRPxnTZiW1PDVnXvGBg5XeuUDoUCi8LRsV3gn', 'sipa');
+  describe('privateKeyStringToKey', () => {
+    let fixtures = [
+      { format: 'base58', key: 'DXuhJcNCPfgjYN8NQFjVh9yri8Rau5B7ixWJjpSeqW7W', addr: '1EgGs4Pd5ygy1ZCvMCgqpkrkMHtawYcnam' },
+      { format: 'base64', key: 'pbc8OCl5SdqjILx4R+yfvljZ7edUr65osjkzjqH2YQw=', addr: '1EL2ha3KWUFa2q7hfLk49XmUfiBV1yCzYG' },
+      { format: 'hex', key: '46DA1C47CF7FE23A97497665C217963F048EBC3E4287734947B180D64C7D81DF', addr: '19CK8suvcJptn96vfvLjfNnbcbEoyHS9G' },
+      { format: 'mini', key: 'S6c56bnXQiBjk9mqSYE7ykVQ7NzrRy', addr: '1PZuicD1ACRfBuKEgp2XaJhVvnwpeETDyn' },
+      { format: 'sipa', key: '5JFXNQvtFZSobCCRPxnTZiW1PDVnXvGBg5XeuUDoUCi8LRsV3gn', addr: '1BDSbDEechSue77wS44Jn2uDiFaQWom2dG' },
+      { format: 'compsipa', key: 'L3dDv2KUyLfPwkcnhALEaHnd47gewa1BVvnCwWL3gVWsb2H27PY9', addr: '1Mum7V38a3fGLiXN3oCrzdf83mZUKNXmGq' }
+    ];
+
+    fixtures.forEach(data => it(`should convert ${data.format} format`, () => {
+      let res = Helpers.privateKeyStringToKey(data.key, data.format);
       expect(Helpers.isKey(res)).toBeTruthy();
-    })
-  );
+      expect(res.getAddress()).toEqual(data.addr);
+    }));
+
+    it('should fail if given an unknown format', () => {
+      let e = new Error('Unsupported Key Format');
+      expect(() => Helpers.privateKeyStringToKey('', 'unknown')).toThrow(e);
+    });
+  });
 
   describe('privateKeyCorrespondsToAddress', () => {
     afterEach(() => {


### PR DESCRIPTION
Before, the checksum was being thrown out for sipa/compsipa:
`keyBytes = tbytes.slice(0, tbytes.length - 4);`

This PR makes it so that BitcoinJS will validate the checksum for us, and throw if it's wrong. Added a bunch of tests before changing anything.