### PR TITLE
Fix hanging test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: node_modules node_modules/sjcl/sjcl.js
 	npm run build
 
 test: build
-	# ./node_modules/karma/bin/karma start karma.conf.js --single-run
+	./node_modules/karma/bin/karma start karma.conf.js --single-run
 
 dist/my-wallet.js: build
 

--- a/tests/helpers_spec.js
+++ b/tests/helpers_spec.js
@@ -132,41 +132,40 @@ describe('Helpers', () => {
   });
 
   describe('asyncOnce', () => {
-    it('should only execute once', done => {
-      let observer = {
-        func () {},
-        before () {}
+    let observer;
+
+    beforeEach(() => {
+      jasmine.clock().install();
+      observer = {
+        func: jasmine.createSpy('func'),
+        before: jasmine.createSpy('before')
       };
-
-      spyOn(observer, 'func');
-      spyOn(observer, 'before');
-
-      let async = Helpers.asyncOnce(observer.func, 20, observer.before);
-
-      async();
-      async();
-      async();
-      async();
-
-      let result = () => {
-        expect(observer.func).toHaveBeenCalledTimes(1);
-        expect(observer.before).toHaveBeenCalledTimes(4);
-
-        done();
-      };
-
-      return setTimeout(result, 1000);
     });
 
-    it('should work with arguments', done => {
-      let observer = {
-        func () {},
-        before () {}
-      };
+    afterEach(() => {
+      jasmine.clock().uninstall();
+    });
 
-      spyOn(observer, 'func');
-      spyOn(observer, 'before');
+    it('should only execute once', () => {
+      let async = Helpers.asyncOnce(observer.func, 20, observer.before);
 
+      async();
+      async();
+      async();
+      async();
+
+      jasmine.clock().tick(10);
+
+      expect(observer.func).toHaveBeenCalledTimes(0);
+      expect(observer.before).toHaveBeenCalledTimes(4);
+
+      jasmine.clock().tick(10);
+
+      expect(observer.func).toHaveBeenCalledTimes(1);
+      expect(observer.before).toHaveBeenCalledTimes(4);
+    });
+
+    it('should work with arguments', () => {
       let async = Helpers.asyncOnce(observer.func, 20, observer.before);
 
       async(1);
@@ -174,15 +173,16 @@ describe('Helpers', () => {
       async(1);
       async(1);
 
-      let result = () => {
-        expect(observer.func).toHaveBeenCalledTimes(1);
-        expect(observer.func).toHaveBeenCalledWith(1);
-        expect(observer.before).toHaveBeenCalledTimes(4);
+      jasmine.clock().tick(10);
 
-        done();
-      };
+      expect(observer.func).toHaveBeenCalledTimes(0);
+      expect(observer.before).toHaveBeenCalledTimes(4);
 
-      return setTimeout(result, 1000);
+      jasmine.clock().tick(10);
+
+      expect(observer.func).toHaveBeenCalledTimes(1);
+      expect(observer.func).toHaveBeenCalledWith(1);
+      expect(observer.before).toHaveBeenCalledTimes(4);
     });
   });
 


### PR DESCRIPTION
Turns out `setTimeout` was the issue, fixed by using the mocked jasmine clock. The tests shouldn't hang anymore.