### PR TITLE
Catch unhandled promise rejections

### DIFF
--- a/src/wallet.js
+++ b/src/wallet.js
@@ -352,8 +352,8 @@ MyWallet.initializeWallet = function (pw, decryptSuccess, buildHdSuccess) {
   var loadMetadata = function () {
     return MyWallet.wallet.loadMetadata();
   };
-  p.then(incStats);
-  p.then(saveGUID);
+  p.then(incStats).catch(() => { /* ignore failure */ });
+  p.then(saveGUID).catch(() => { /* ignore failure */ });
   return p.then(loadMetadata);
 };
 


### PR DESCRIPTION
If a promise rejects in Node and isn't caught, it generates a warning:

```
(node:47665) UnhandledPromiseRejectionWarning: Unhandled promise rejection
(node:47665) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

This PR is to prevent the warning and (in future versions of Node) unnecessary crashes.