### PR TITLE
fix(faster-sync): adding less addresses to be notified if the numbers…

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -516,4 +516,23 @@ Helpers.deepClone = function (object) {
   return JSON.parse(JSON.stringify(object));
 };
 
+Helpers.addressesePerAccount = function (n) {
+  switch (true) {
+    case n > 0 && n < 4:
+      return 20;
+    case n > 3 && n < 7:
+      return 15;
+    case n > 6 && n < 11:
+      return 10;
+    case n > 10 && n < 21:
+      return 5;
+    case n > 20 && n < 31:
+      return 3;
+    case n > 30 && n < 51:
+      return 2;
+    default:
+      return 1;
+  }
+};
+
 module.exports = Helpers;

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -15,6 +15,7 @@ var BIP39 = require('bip39');
 var Bitcoin = require('bitcoinjs-lib');
 var pbkdf2 = require('pbkdf2');
 var constants = require('./constants');
+var range = require('ramda/src/range');
 
 var isInitialized = false;
 MyWallet.wallet = undefined;
@@ -477,11 +478,13 @@ function syncWallet (successcallback, errorcallback) {
           // Include HD addresses unless in lame mode:
           var hdAddresses = [];
           if (MyWallet.wallet.hdwallet !== undefined && MyWallet.wallet.hdwallet.accounts !== undefined) {
+            var nAccounts = MyWallet.wallet.hdwallet.accounts.length;
+            var nAddresses = range(0, Helpers.addressesePerAccount(nAccounts));
             var subscribeAccount = function (acc) {
               var ri = acc.receiveIndex;
               var labeled = acc.labeledReceivingAddresses ? acc.labeledReceivingAddresses : [];
               var getAddress = function (i) { return acc.receiveAddressAtIndex(i + ri); };
-              return [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19].map(getAddress).concat(labeled);
+              return nAddresses.map(getAddress).concat(labeled);
             };
             hdAddresses = MyWallet.wallet.hdwallet.accounts.map(subscribeAccount).reduce(function (a, b) { return a.concat(b); }, []);
           }


### PR DESCRIPTION
… of accounts grow

Having email notifications and more than 5 accounts produces a UI block when saving the first time. This is because we have to derive 20 addresses per account. In the future we might change the notifications to be able to subscribe for xpubs, but for now this fix will produce a better UX.