### PR TITLE
Include missing core-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bitcoin-sfox-client": "^0.1.11",
     "bitcoinjs-lib": "2.1.*",
     "bs58": "2.0.*",
+    "core-js": "^2.4.1",
     "es6-promise": "^3.0.2",
     "isomorphic-fetch": "^2.2.1",
     "pbkdf2": "^3.0.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1383,7 +1383,7 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
-core-js@^2.2.0, core-js@^2.4.0:
+core-js@^2.2.0, core-js@^2.4.0, core-js@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 


### PR DESCRIPTION
core-js is imported in src/index.js as a polyfill, but we don't list it as a dependency. This causes issues when installing with npm@2.