### PR TITLE
Add `read` property to facilitated tx

### DIFF
--- a/src/contact.js
+++ b/src/contact.js
@@ -43,14 +43,14 @@ Contact.prototype.fetchXPUB = function () {
 };
 
 // create and add a request payment request to that contact facilitated tx list
-Contact.prototype.RPR = function (intendedAmount, id, role, note, initiatorSource) {
-  const rpr = FacilitatedTx.RPR(intendedAmount, id, role, note, initiatorSource);
+Contact.prototype.RPR = function (intendedAmount, id, role, note, initiatorSource, showNotificationBadge) {
+  const rpr = FacilitatedTx.RPR(intendedAmount, id, role, note, initiatorSource, showNotificationBadge);
   this.facilitatedTxList = assoc(id, rpr, this.facilitatedTxList);
   return rpr;
 };
 
 // create and/or add a payment request to that contact facilitated tx list
-Contact.prototype.PR = function (intendedAmount, id, role, address, note, initiatorSource) {
+Contact.prototype.PR = function (intendedAmount, id, role, address, note, initiatorSource, showNotificationBadge) {
   var existingTx = prop(id, this.facilitatedTxList);
   if (existingTx) {
     existingTx.address = address;
@@ -58,7 +58,7 @@ Contact.prototype.PR = function (intendedAmount, id, role, address, note, initia
     existingTx.last_updated = Date.now();
     return existingTx;
   } else {
-    const pr = FacilitatedTx.PR(intendedAmount, id, role, address, note, initiatorSource);
+    const pr = FacilitatedTx.PR(intendedAmount, id, role, address, note, initiatorSource, showNotificationBadge);
     this.facilitatedTxList = assoc(id, pr, this.facilitatedTxList);
     return pr;
   }
@@ -88,4 +88,11 @@ Contact.prototype.Cancel = function (id) {
   existingTx.last_updated = Date.now();
   return existingTx;
 };
+
+Contact.prototype.HideNotificationBadge = function (id) {
+  var existingTx = prop(id, this.facilitatedTxList);
+  existingTx.show_notification_badge = false;
+  return existingTx;
+}
+
 module.exports = Contact;

--- a/src/contact.js
+++ b/src/contact.js
@@ -44,7 +44,7 @@ Contact.prototype.fetchXPUB = function () {
 
 // create and add a request payment request to that contact facilitated tx list
 Contact.prototype.RPR = function (intendedAmount, id, role, note, initiatorSource) {
-  const rpr = FacilitatedTx.RPR(intendedAmount, id, role, note, initiatorSource, 1);
+  const rpr = FacilitatedTx.RPR(intendedAmount, id, role, note, initiatorSource, 0);
   this.facilitatedTxList = assoc(id, rpr, this.facilitatedTxList);
   return rpr;
 };
@@ -56,10 +56,10 @@ Contact.prototype.PR = function (intendedAmount, id, role, address, note, initia
     existingTx.address = address;
     existingTx.state = FacilitatedTx.WAITING_PAYMENT;
     existingTx.last_updated = Date.now();
-    existingTx.show_notification_badge = 1;
+    existingTx.read = 0;
     return existingTx;
   } else {
-    const pr = FacilitatedTx.PR(intendedAmount, id, role, address, note, initiatorSource, 1);
+    const pr = FacilitatedTx.PR(intendedAmount, id, role, address, note, initiatorSource, 0);
     this.facilitatedTxList = assoc(id, pr, this.facilitatedTxList);
     return pr;
   }
@@ -90,9 +90,9 @@ Contact.prototype.Cancel = function (id) {
   return existingTx;
 };
 
-Contact.prototype.HideNotificationBadge = function (id) {
+Contact.prototype.Read = function (id) {
   var existingTx = prop(id, this.facilitatedTxList);
-  existingTx.show_notification_badge = 0;
+  existingTx.read = 1;
   return existingTx;
 }
 

--- a/src/contact.js
+++ b/src/contact.js
@@ -43,22 +43,23 @@ Contact.prototype.fetchXPUB = function () {
 };
 
 // create and add a request payment request to that contact facilitated tx list
-Contact.prototype.RPR = function (intendedAmount, id, role, note, initiatorSource, showNotificationBadge) {
-  const rpr = FacilitatedTx.RPR(intendedAmount, id, role, note, initiatorSource, showNotificationBadge);
+Contact.prototype.RPR = function (intendedAmount, id, role, note, initiatorSource) {
+  const rpr = FacilitatedTx.RPR(intendedAmount, id, role, note, initiatorSource, 1);
   this.facilitatedTxList = assoc(id, rpr, this.facilitatedTxList);
   return rpr;
 };
 
 // create and/or add a payment request to that contact facilitated tx list
-Contact.prototype.PR = function (intendedAmount, id, role, address, note, initiatorSource, showNotificationBadge) {
+Contact.prototype.PR = function (intendedAmount, id, role, address, note, initiatorSource) {
   var existingTx = prop(id, this.facilitatedTxList);
   if (existingTx) {
     existingTx.address = address;
     existingTx.state = FacilitatedTx.WAITING_PAYMENT;
     existingTx.last_updated = Date.now();
+    existingTx.show_notification_badge = 1;
     return existingTx;
   } else {
-    const pr = FacilitatedTx.PR(intendedAmount, id, role, address, note, initiatorSource, showNotificationBadge);
+    const pr = FacilitatedTx.PR(intendedAmount, id, role, address, note, initiatorSource, 1);
     this.facilitatedTxList = assoc(id, pr, this.facilitatedTxList);
     return pr;
   }
@@ -91,7 +92,7 @@ Contact.prototype.Cancel = function (id) {
 
 Contact.prototype.HideNotificationBadge = function (id) {
   var existingTx = prop(id, this.facilitatedTxList);
-  existingTx.show_notification_badge = false;
+  existingTx.show_notification_badge = 0;
   return existingTx;
 }
 

--- a/src/contacts.js
+++ b/src/contacts.js
@@ -265,10 +265,10 @@ Contacts.prototype.sendCancellation = function (userId, id) {
     .then(this.save.bind(this));
 };
 
-Contacts.prototype.hideNotificationBadge = function (userId, id) {
+Contacts.prototype.read = function (userId, id) {
   const message = generalResponse(id);
   const contact = this.get(userId);
-  contact.HideNotificationBadge(id);
+  contact.Read(id);
   return this.save();
 };
 // /////////////////////////////////////////////////////////////////////////////
@@ -285,7 +285,7 @@ Contacts.prototype.digestRPR = function (message) {
             FacilitatedTx.RPR_RECEIVER,
             message.payload.note,
             message.payload.initiator_source,
-            message.payload.show_notification_badge))
+            message.payload.read))
     .then(this.save.bind(this))
     .then(() => message);
 };
@@ -325,7 +325,7 @@ Contacts.prototype.digestPR = function (message) {
             message.payload.address,
             message.payload.note,
             message.payload.initiator_source,
-            message.payload.show_notification_badge))
+            message.payload.read))
     .then(this.save.bind(this))
     .then(() => message);
 };

--- a/src/contacts.js
+++ b/src/contacts.js
@@ -204,8 +204,13 @@ const paymentRequestResponse = function (id, txHash) {
 };
 Contacts.prototype.paymentRequestResponse = R.compose(JSON.parse, paymentRequestResponse)
 
-// :: returns a message string of a general response
-const generalResponse = function (id) {
+// :: returns a message string of a decline response
+const declineResponse = function (id) {
+  return JSON.stringify({id: id});
+};
+
+// :: returns a message string of a cancel response
+const cancelResponse = function (id) {
   return JSON.stringify({id: id});
 };
 
@@ -250,7 +255,7 @@ Contacts.prototype.sendPRR = function (userId, txHash, id) {
 
 // decline response
 Contacts.prototype.sendDeclination = function (userId, id) {
-  const message = generalResponse(id);
+  const message = declineResponse(id);
   const contact = this.get(userId);
   return this.sendMessage(userId, DECLINE_RESPONSE_TYPE, message)
     .then(contact.Decline.bind(contact, id))
@@ -258,7 +263,7 @@ Contacts.prototype.sendDeclination = function (userId, id) {
 };
 // cancel response
 Contacts.prototype.sendCancellation = function (userId, id) {
-  const message = generalResponse(id);
+  const message = cancelResponse(id);
   const contact = this.get(userId);
   return this.sendMessage(userId, CANCEL_RESPONSE_TYPE, message)
     .then(contact.Cancel.bind(contact, id))
@@ -266,7 +271,6 @@ Contacts.prototype.sendCancellation = function (userId, id) {
 };
 
 Contacts.prototype.read = function (userId, id) {
-  const message = generalResponse(id);
   const contact = this.get(userId);
   contact.Read(id);
   return this.save();

--- a/src/contacts.js
+++ b/src/contacts.js
@@ -268,9 +268,8 @@ Contacts.prototype.sendCancellation = function (userId, id) {
 Contacts.prototype.hideNotificationBadge = function (userId, id) {
   const message = generalResponse(id);
   const contact = this.get(userId);
-  return this.sendMessage(userId, null, message)
-    .then(contact.HideNotificationBadge.bind(contact, id))
-    .then(this.save.bind(this));
+  contact.HideNotificationBadge(id);
+  return this.save();
 };
 // /////////////////////////////////////////////////////////////////////////////
 // digestion logic

--- a/src/contacts.js
+++ b/src/contacts.js
@@ -296,7 +296,7 @@ Contacts.prototype.digestDecline = function (message) {
   const result = this.search(message.sender);
   const contact = result[Object.keys(result)[0]];
   return this._sharedMetadata.processMessage(message.id)
-    .then(contact.Cancel.bind(contact, message.payload.id))
+    .then(contact.Decline.bind(contact, message.payload.id))
     .then(this.save.bind(this))
     .then(() => message);
 };

--- a/src/facilitatedTx.js
+++ b/src/facilitatedTx.js
@@ -12,11 +12,12 @@ class FacilitatedTx {
     this.created = o.created;
     this.last_updated = o.last_updated;
     this.initiator_source = o.initiator_source;
+    this.show_notification_badge = o.show_notification_badge;
   }
 }
 
 // create a Request for a Payment Request
-FacilitatedTx.RPR = function (intendedAmount, id, role, note, initiatorSource) {
+FacilitatedTx.RPR = function (intendedAmount, id, role, note, initiatorSource, showNotificationBadge) {
   return new FacilitatedTx(
     {
       state: FacilitatedTx.WAITING_ADDRESS,
@@ -26,12 +27,13 @@ FacilitatedTx.RPR = function (intendedAmount, id, role, note, initiatorSource) {
       note: note,
       created: Date.now(),
       last_updated: Date.now(),
-      initiator_source: initiatorSource
+      initiator_source: initiatorSource,
+      show_notification_badge: showNotificationBadge
     });
 };
 
 // create a payment request
-FacilitatedTx.PR = function (intendedAmount, id, role, address, note, initiatorSource) {
+FacilitatedTx.PR = function (intendedAmount, id, role, address, note, initiatorSource, showNotificationBadge) {
   return new FacilitatedTx(
     {
       state: FacilitatedTx.WAITING_PAYMENT,
@@ -42,7 +44,8 @@ FacilitatedTx.PR = function (intendedAmount, id, role, address, note, initiatorS
       note: note,
       created: Date.now(),
       last_updated: Date.now(),
-      initiator_source: initiatorSource
+      initiator_source: initiatorSource,
+      show_notification_badge: showNotificationBadge
     });
 };
 

--- a/src/facilitatedTx.js
+++ b/src/facilitatedTx.js
@@ -12,12 +12,12 @@ class FacilitatedTx {
     this.created = o.created;
     this.last_updated = o.last_updated;
     this.initiator_source = o.initiator_source;
-    this.show_notification_badge = o.show_notification_badge;
+    this.read = o.read;
   }
 }
 
 // create a Request for a Payment Request
-FacilitatedTx.RPR = function (intendedAmount, id, role, note, initiatorSource, showNotificationBadge) {
+FacilitatedTx.RPR = function (intendedAmount, id, role, note, initiatorSource, read) {
   return new FacilitatedTx(
     {
       state: FacilitatedTx.WAITING_ADDRESS,
@@ -28,12 +28,12 @@ FacilitatedTx.RPR = function (intendedAmount, id, role, note, initiatorSource, s
       created: Date.now(),
       last_updated: Date.now(),
       initiator_source: initiatorSource,
-      show_notification_badge: showNotificationBadge
+      read: read
     });
 };
 
 // create a payment request
-FacilitatedTx.PR = function (intendedAmount, id, role, address, note, initiatorSource, showNotificationBadge) {
+FacilitatedTx.PR = function (intendedAmount, id, role, address, note, initiatorSource, read) {
   return new FacilitatedTx(
     {
       state: FacilitatedTx.WAITING_PAYMENT,
@@ -45,7 +45,7 @@ FacilitatedTx.PR = function (intendedAmount, id, role, address, note, initiatorS
       created: Date.now(),
       last_updated: Date.now(),
       initiator_source: initiatorSource,
-      show_notification_badge: showNotificationBadge
+      read: read
     });
 };
 


### PR DESCRIPTION
Added property `read` for the purpose of push notification badges. Had to use `0` and `1` due to time constraints, since there is currently a conversion issue with iOS reading `true` and `false` from the mapped object.